### PR TITLE
Watchlistの削除機能を実装

### DIFF
--- a/app/controllers/watchlists_controller.rb
+++ b/app/controllers/watchlists_controller.rb
@@ -32,6 +32,12 @@ class WatchlistsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+
+  def destroy
+    watchlist = current_user.watchlists.find(params[:id])
+    watchlist.destroy!
+    redirect_to watchlists_path, notice: 'これからの予定から削除しました', status: :see_other
+end
  
   private
 

--- a/app/views/watchlists/edit.html.erb
+++ b/app/views/watchlists/edit.html.erb
@@ -1,3 +1,20 @@
+<header class="bg-white/80 backdrop-blur-sm sticky top-0 z-40 transition-colors border-b border-white">
+  <div class="max-w-full mx-auto px-4 py-3">
+    <div class="flex items-center justify-between w-full">
+      <div class="flex items-center gap-3">
+        <%= link_to watchlist_path, class: "material-symbols-outlined text-primary hover:opacity-70 transition-opacity" do %>
+          arrow_back
+        <% end %>
+        <h1 class="font-headline font-bold text-lg text-primary">予定の詳細</h1>
+      </div>
+      <div class="flex items-center gap-2 bg-white/50 px-3 py-1.5 rounded-full border border-white shadow-sm">
+        <%= image_tag "logo.png", class: "w-6 h-6 object-contain", alt: "FanPocket Logo" %>
+        <span class="font-headline font-bold tracking-tight text-primary">FanPocket</span>
+      </div>
+    </div>
+  </div>
+</header>
+
 <main class="flex-grow px-6 max-w-3xl mx-auto w-full pt-8">
   <div class="mb-10">
     <h2 class="font-headline font-extrabold text-3xl text-center text-primary tracking-tight">予定の編集</h2>
@@ -6,7 +23,4 @@
 
   <%= render 'form', watchlist: @watchlist %>
 
-  <div class="text-center -mt-12 mb-20">
-    <%= link_to '戻る', watchlist_path(@watchlist), class: "text-gray-400 text-sm hover:underline" %>
-  </div>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   # config/routes.rb
-  resources :watchlists, only: [:index, :show, :new, :create, :edit, :update]
+  resources :watchlists, only: [:index, :show, :new, :create, :edit, :update, :destroy]
 end


### PR DESCRIPTION
概要
不要になった予定を削除できるようにする。

タスク

削除処理（destroy）の実装（JavaScriptによる削除確認ダイアログ付き）

自分の投稿のみが削除可能であることの確認

編集画面の戻るボタンを削除し、ヘッダーに遷移リンクを追加

デプロイし確認済みです。