### PR TITLE
ステータス管理機能の実装

### DIFF
--- a/app/controllers/watchlists_controller.rb
+++ b/app/controllers/watchlists_controller.rb
@@ -2,10 +2,20 @@ class WatchlistsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_watchlist, only: [:show, :edit, :update]
 
-  def index
-    @watchlists =current_user.watchlists.order(start_at: :asc, end_at: :asc)
-  end
+ def index
+    # 1. 「これからの予定」：まだ完了していなくて（is_done: false）、終了日時が未来、または未設定のもの
+    @future_watchlists = current_user.watchlists
+                                     .where(is_done: false)
+                                     .where("end_at >= ? OR end_at IS NULL", Time.current)
+                                     .order(start_at: :asc)
 
+    # 2. 「これまでの足跡」：すでに完了している（is_done: true）か、または終了日時が過去のもの
+    @past_watchlists = current_user.watchlists
+                                   .where(is_done: true)
+                                   .or(current_user.watchlists.where("end_at < ?", Time.current))
+                                   .order(end_at: :desc)
+  end
+  
   def show
   end
 
@@ -61,6 +71,6 @@ class WatchlistsController < ApplicationController
   end
 
   def watchlist_params
-    params.require(:watchlist).permit(:title, :memo, :url, :start_at, :end_at, :is_done, :image)
+    params.require(:watchlist).permit(:title, :memo, :url, :start_at, :end_at, :is_done)
   end
 end

--- a/app/views/watchlists/_form.html.erb
+++ b/app/views/watchlists/_form.html.erb
@@ -55,6 +55,13 @@
     <%= f.text_area :memo, class: "w-full min-h-[120px] pl-12 pr-8 py-5 bg-[#f0f4f8] border-none rounded-[32px] shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-400/60 leading-relaxed", placeholder: "持ち物、連番相手の連絡先など..." %>
   </div>
 
+  <div class="form-control mb-4 pb-4">
+    <label class="label cursor-pointer justify-start gap-3">
+      <%= f.check_box :is_done, class: "toggle toggle-primary" %>
+      <span class="label-text font-bold text-primary">完了にする</span>
+    </label>
+  </div>
+
   <div class="pt-6 pb-20"> 
     <%= f.button class: "w-full bg-[#B6E0F3] text-[#2d6489] font-headline font-bold py-4 rounded-full puffy-shadow hover:brightness-105 transition-all active:scale-[0.97] flex items-center justify-center gap-3", type: "submit" do %>
       <span class="material-symbols-outlined font-bold">save</span>

--- a/app/views/watchlists/_watchlist_card.html.erb
+++ b/app/views/watchlists/_watchlist_card.html.erb
@@ -1,6 +1,6 @@
 <%= link_to watchlist_path(watchlist), class: "block transition-transform duration-200 active:scale-[0.98]" do %>
   <div class="relative group bg-white rounded-xl p-5 sticky-note-shadow flex items-center justify-between border-l-8 <%= is_past ? 'border-gray-300' : 'border-[#B6E0F3]' %>">
-    <div class="flex-1 pr-4">
+    <div class="flex-1 pr-4 <%= 'opacity-60' if is_past || watchlist.is_done? %>">
       <p class="font-label text-xs text-on-surface-variant/70 mb-1">
         <%= watchlist.start_at&.strftime("%Y.%m.%d %H:%M") %>
       </p>
@@ -9,17 +9,27 @@
       </h3>
     </div>
     
-    <div class="flex flex-col items-end gap-2">
-      <% if !is_past && watchlist.end_at.present? %>
+    <div class="flex flex-col items-end gap-2 <%= 'opacity-60' if is_past || watchlist.is_done? %>">
+      <% if watchlist.is_done? %>
+        <%# 1. 対応済みの場合 %>
+        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic">対応済み</span>
+      <% elsif !is_past && watchlist.end_at.present? && watchlist.end_at >= Time.current %>
+        <%# 2. これからの予定（まだ期限が来ていない） %>
         <% days_left = (watchlist.end_at.to_date - Date.today).to_i %>
         <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
           <%= days_left <= 0 ? "本日締切" : "あと#{days_left}日" %>
         </span>
+      <% elsif watchlist.end_at.present? && watchlist.end_at < Time.current %>
+        <%# 3. 未完了のまま期限が過ぎた場合（受付終了） %>
+        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic">受付終了</span>
       <% elsif is_past %>
-        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic ">思い出</span>
+        <%# 4. それ以外の過去の予定（思い出） %>
+        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic">思い出</span>
       <% end %>
-      <span class="material-symbols-outlined <%= is_past ? 'text-gray-300' : 'text-[#B6E0F3]' %>">
-        <%= is_past ? 'inventory_2' : 'push_pin' %>
+
+      <%# アイコンの切り替え（足跡セクション、または対応済みならグレーの箱になります） %>
+      <span class="material-symbols-outlined <%= (is_past || watchlist.is_done?) ? 'text-gray-300' : 'text-[#B6E0F3]' %>">
+        <%= (is_past || watchlist.is_done?) ? 'inventory_2' : 'push_pin' %>
       </span>
     </div>
   </div>

--- a/app/views/watchlists/index.html.erb
+++ b/app/views/watchlists/index.html.erb
@@ -1,16 +1,12 @@
 <main class="max-w-screen-xl mx-auto px-6 mt-16 pb-40">
-  <%# 現在時刻を基準に未来と過去に分ける %>
-  <% future_watchlists = @watchlists.select { |w| w.end_at.nil? || w.end_at >= Time.current } %>
-  <% past_watchlists = @watchlists.select { |w| w.end_at.present? && w.end_at < Time.current } %>
-
-    <% if alert %>
+  <% if alert %>
     <div class="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-xs">
-        <div class="alert alert-soft alert-error shadow-lg rounded-2xl">
+      <div class="alert alert-soft alert-error shadow-lg rounded-2xl">
         <span class="material-symbols-outlined text-[20px] ">warning</span>
         <span class="text-sm font-bold text-left"><%= alert %></span>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
   <!-- これからの予定セクション -->
   <!-- Date Header Section -->
@@ -18,9 +14,9 @@
     <h2 class="font-headline font-extrabold text-3xl tracking-tight text-primary">これからの予定</h2>
   </div>
   <div class="mb-6">
-    <% if future_watchlists.any? %>
+    <% if @future_watchlists.any? %>
       <div class="space-y-6">
-        <% future_watchlists.each do |watchlist| %>
+        <% @future_watchlists.each do |watchlist| %>
           <%= render 'watchlist_card', watchlist: watchlist, is_past: false %>
         <% end %>
       </div>
@@ -34,7 +30,7 @@
   </div>
 
   <!-- 終わった予定（思い出）セクション -->
-  <% if past_watchlists.any? %>
+  <% if @past_watchlists.any? %>
     <div class="mt-12 mb-6 px-2 ">
     <div class="divider font-headline text-sm opacity-40 gap-1">
       <span>これまでの足跡</span>
@@ -42,7 +38,7 @@
         footprint
       </span>
     </div>
-        <% past_watchlists.each do |watchlist| %>
+        <% @past_watchlists.each do |watchlist| %>
           <div class="space-y-6">
           <%= render 'watchlist_card', watchlist: watchlist, is_past: true %>
         <% end %>

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -49,8 +49,8 @@
       
       <%# 1. ユーザーが「完了」チェックを入れた場合 %>
       <% if @watchlist.is_done? %>
-        <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center shrink-0">
-          <span class="material-symbols-outlined text-gray-500 text-xl">done_all</span>
+        <div class="w-10 h-10 rounded-full bg-teal-100 flex items-center justify-center shrink-0">
+          <span class="material-symbols-outlined text-teal-500 text-xl">done_all</span>
         </div>
         <span class="text-gray-500 font-bold text-lg">対応済み</span>
 

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -33,23 +33,35 @@
     </div>
   </section>
 
-  <div class="space-y-6">
+<div class="space-y-6">
   <div class="bg-white p-6 rounded-3xl puffy-shadow relative overflow-hidden">
     <div class="absolute top-0 right-0 w-10 h-10 bg-tertiary-container/10 rounded-bl-3xl"></div>
     
     <div class="flex items-center gap-2 mb-4">
       <span class="material-symbols-outlined text-primary/60 text-xl">
-        <%= (@watchlist.end_at && @watchlist.end_at < Time.current) ? 'check_circle' : 'hourglass_empty' %>
+        <%# 最優先で完了か、それ以外（受付終了・未対応）かでアイコンを切り替え %>
+        <%= @watchlist.is_done? ? 'check_circle' : 'hourglass_empty' %>
       </span>
       <span class="text-primary/60 text-xs font-bold uppercase tracking-widest font-headline">現在のステータス</span>
     </div>
 
     <div class="w-full px-6 py-5 bg-[#f0f4f8] border-none rounded-[32px] flex items-center gap-4">
-      <% if @watchlist.end_at && @watchlist.end_at < Time.current %>
+      
+      <%# 1. ユーザーが「完了」チェックを入れた場合 %>
+      <% if @watchlist.is_done? %>
         <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center shrink-0">
           <span class="material-symbols-outlined text-gray-500 text-xl">done_all</span>
         </div>
         <span class="text-gray-500 font-bold text-lg">対応済み</span>
+
+      <% # 2. チェックはないが、終了日時を過ぎている場合（受付終了） %>
+      <% elsif @watchlist.end_at && @watchlist.end_at < Time.current %>
+        <div class="w-10 h-10 rounded-full bg-amber-100 flex items-center justify-center shrink-0">
+          <span class="material-symbols-outlined text-amber-600 text-xl">event_busy</span>
+        </div>
+        <span class="text-amber-700 font-bold text-lg">受付終了</span>
+
+      <% # 3. まだどちらでもない場合（未対応） %>
       <% else %>
         <div class="relative flex shrink-0">
           <div class="w-10 h-10 rounded-full bg-sky-100 flex items-center justify-center">
@@ -59,6 +71,7 @@
         </div>
         <span class="text-sky-600 font-bold text-lg">未対応</span>
       <% end %>
+
     </div>
   </div>
 


### PR DESCRIPTION
概要
予定の「未対応/完了」を切り替える機能を実装しました。

タスク

status カラム（boolean）の切り替え処理を実装（追加画面、編集画面）

一覧画面でステータスに応じたバッジ表示などの切り替え

「完了」した予定を通知対象から除外するロジックの準備

デプロイし確認しました。