### PR TITLE
3日前通知の実装

### DIFF
--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -4,6 +4,13 @@ class Watchlist < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validate :start_at_or_end_at_must_be_present
 
+  scope :alert_three_days_prior, -> {
+    start_of_day = 3.days.from_now.beginning_of_day
+    end_of_day   = 3.days.from_now.end_of_day
+
+    where(is_done: false, end_at: start_of_day..end_of_day)
+  }
+
   private
 
   def start_at_or_end_at_must_be_present

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -1,0 +1,22 @@
+namespace :notification do
+  desc "締切3日前の未対応タスクがあるユーザーに通知を送る"
+  task send_3days_prior: :environment do
+    targets = Watchlist.alert_three_days_prior
+
+    puts "--- 3日前通知バッチ処理 開始 (対象: #{targets.count}件) ---"
+
+    targets.each do |watchlist|
+      user = watchlist.user
+      
+      user_email = user.email
+      title      = watchlist.title
+      content    = "「#{watchlist.title}」の締め切りまであと3日です。大切な予定を見逃さないようにご確認ください。" 
+
+      NotificationMailer.three_days_ago_notice(user_email, title, content).deliver_now
+      
+      puts "通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
+    end
+
+    puts "--- 3日前通知バッチ処理 終了 ---"
+  end
+end


### PR DESCRIPTION
## 概要
「未対応」かつ「期日の3日前」のWatchlistデータをもつユーザーに対して、通知メールを送信するコアロジックおよびRakeタスクを実装しました。

## 背景
ユーザーが登録したイベントやタスクの締切3日前になった時点で自動通知を送り、ユーザーの買い逃しや対応漏れを防ぐため。
※インフラ連携（GitHub ActionsやUpstash）を導入する前段階として、まずはRailsアプリ内で確実に動作するバックエンドロジックの土台が必要であったため、本変更を行いました。
（3日前通知の送信ロジック実装
#19）

## 変更内容
- **Model (`app/models/watchlist.rb`)**:
  - `is_done: false` かつ `end_at` が3日後の期間（`beginning_of_day` 〜 `end_of_day`）に収まっているデータを正確に抽出するスコープ `alert_three_days_prior` を定義しました。
- **Rakeタスク (`lib/tasks/notification.rake`)**:
  - ターミナルから `bin/rails notification:send_3days_prior` で実行できるバッチ処理コマンドを作成しました。
  - 抽出した対象データからユーザー情報、タイトル、文面を動的に組み立て、既存の `NotificationMailer.three_days_ago_notice` を用いて即時送信（`.deliver_now`）する処理を統合しました。

## 確認方法
1. `rails console` を起動し、検証用のユーザーを紐付けた以下3パターンのテストデータを作成
   - 条件一致：未対応 ＆ 3日後締切 -> `Watchlist.create!(title: "ヒットするはず", is_done: false, end_at: 3.days.from_now, user: user)`
   - 条件外①：対応済 ＆ 3日後締切 -> `Watchlist.create!(title: "完了済なので出ないはず", is_done: true, end_at: 3.days.from_now, user: user)`
   - 条件外②：未対応 ＆ 1日後締切 -> `Watchlist.create!(title: "明日締切なので出ないはず", is_done: false, end_at: 1.day.from_now, user: user)`
2. ターミナルからRakeタスクを実行
   `docker compose exec web bin/rails notification:send_3days_prior`
3. 実行結果の確認
   エラーが出ずに以下のログが出力され、条件一致データ（および元からローカルにあった3日後締切のデータ）のみが狙い通りに抽出・送信完了となることを確認しました。

~~~
--- 3日前通知バッチ処理 開始 (対象: 2件) ---
通知送信完了: [Watchlist ID: 3] to [User: aoha@example.com]
通知送信完了: [Watchlist ID: 7] to [User: aoha@example.com
--- 3日前通知バッチ処理 終了 ---
~~~
※localhost:3000のブラウザ上のデータとも一致していることを目視確認済みです。

## 補足
- 当初は非同期ジョブ（Sidekiq）や定期実行（GitHub Actions）の設定まで一気に実装する予定でしたが、エラーが起きた際の原因特定（ロジックのバグなのか、インフラの設定ミスなのか）を容易にするため、あえて「純粋なRails側のロジック作成」を独立したIssueとして切り離して実装しました。