### PR TITLE
[インフラ] GitHub Actions ＋ Upstash ＋ Sidekiq による通知基盤の構築

### DIFF
--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -1,0 +1,17 @@
+name: Wake up Render Service
+
+on:
+  schedule:
+    # 21:55 (UTC) = 日本時間 6:55 (7:00の通知用)
+    # 10:55 (UTC) = 日本時間 19:55 (20:00の通知用)
+    - cron: '55 10,21 * * *'
+  workflow_dispatch: # 手動で実行するためのボタンをGitHub上に表示させます
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send a ping request to Render
+        run: |
+          curl -s "${{ secrets.RENDER_APP_URL }}" > /dev/null
+          echo "Ping sent to Render app successfully."

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem 'resend'
 gem 'letter_opener'
 gem 'letter_opener_web', '~> 3.0'
 
+gem 'sidekiq'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
+    json (2.19.5)
     launchy (3.1.1)
       addressable (~> 2.8)
       childprocess (~> 5.0)
@@ -243,6 +244,8 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redis-client (0.29.0)
+      connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -261,6 +264,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    sidekiq (8.1.5)
+      connection_pool (>= 3.0.0)
+      json (>= 2.16.0)
+      logger (>= 1.7.0)
+      rack (>= 3.2.0)
+      redis-client (>= 0.29.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -318,6 +327,7 @@ DEPENDENCIES
   rails-i18n
   resend
   selenium-webdriver
+  sidekiq
   sprockets-rails
   stimulus-rails
   tailwindcss-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,6 +91,7 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
   
+  config.active_job.queue_adapter = :sidekiq
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+:concurrency: 5
+:queues:
+  - default
+  - mailers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,13 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7.2-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
   web:
     build: 
       context: .
@@ -28,12 +35,29 @@ services:
       - bundle_data:/usr/local/bundle:cached
     environment:
       TZ: Asia/Tokyo
+      REDIS_URL: redis://redis:6379/1
     ports:
       - "3000:3000"
     depends_on:
-      db:
-        condition: service_healthy
+      - db
+      - redis
+
+  sidekiq:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: bundle exec sidekiq -C config/sidekiq.yml
+    volumes:
+      - .:/app
+      - bundle_data:/usr/local/bundle:cached
+    environment:
+      TZ: Asia/Tokyo
+      REDIS_URL: redis://redis:6379/1
+    depends_on:
+      - db
+      - redis
 
 volumes:
   db_data:
   bundle_data:
+  redis_data:


### PR DESCRIPTION
## 概要
非同期処理を行うためのSidekiqとRedis（ローカル環境およびUpstash）を導入し、Renderの無料枠スリープ対策としてGitHub Actionsによる定期実行（Ping）を設定しました。

## 背景
ユーザーへの定期通知（3日前20時、前日20時、当日7時）をバックグラウンドで確実に実行するため。また、Renderの無料枠仕様による15分での自動スリープを防ぎ、通知のタイミングに合わせて確実にアプリを起動させる必要があったためです（#13）。

## 変更内容
- `Gemfile`: 非同期処理用の `sidekiq` ジェムを追加
- `config/sidekiq.yml`: Sidekiqのプロセス・キュー設定ファイルを新規作成
- `config/environments/production.rb`: 本番環境（Render）のキューアダプターとしてSidekiqを指定
- `docker-compose.yml`: ローカル開発環境用に `redis` および `sidekiq` サービスを追加
- `.github/workflows/ping-render.yml`: 通知時間（日本時間20時・7時）の5分前にRenderのURLへcurlリクエストを送信してアプリを起動させるGitHub Actionsワークフローを新規作成

## 確認方法
1. ローカル環境（Docker）にて `docker compose up -d` を実行し、コンテナが正常に起動することを確認。
2. `docker compose logs sidekiq` を実行し、エラーなくローカルのRedis（`redis://redis:6379/1`）に接続できていることを確認。
3. GitHub Actionsにてワークフローファイルが読み込まれ、手動トリガー（`workflow_dispatch`）による起動が成功することを確認。

## 影響範囲
- バックグラウンドジョブ（Sidekiq）基盤
- 既存の画面UIやログイン機能（Devise）など、同期的なWebアクセスへの影響はありません。

## 動作確認ログ

ローカル環境（Docker）でSidekiqが正常に起動し、Redisに接続できていることを確認しました。
~~~

aoha@DESKTOP-2T8Q4LE:~/app/FanPocket$ docker compose logs sidekiq

sidekiq-1  | INFO  2026-05-25T10:20:52.254Z pid=1 tid=39t: Booted Rails 7.1.6 application in development environment

sidekiq-1  | Signal INFO not supported

sidekiq-1  | INFO  2026-05-25T10:20:52.254Z pid=1 tid=39t: Running in ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]

sidekiq-1  | INFO  2026-05-25T10:20:52.254Z pid=1 tid=39t: See LICENSE and the LGPL-3.0 for licensing details.

sidekiq-1  | INFO  2026-05-25T10:20:52.254Z pid=1 tid=39t: Upgrade to Sidekiq Pro for more features and support: https://sidekiq.org

sidekiq-1  | INFO  2026-05-25T10:20:52.255Z pid=1 tid=39t: Sidekiq 8.1.5 connecting to Redis with options {:size=>10, :pool_name=>"internal", :url=>"redis://redis:6379/1"}

sidekiq-1  | INFO  2026-05-25T10:20:52.259Z pid=1 tid=39t: Sidekiq 8.1.5 connecting to Redis with options {:size=>5, :pool_name=>"default", :url=>"redis://redis:6379/1"}

~~~ 

## 補足
GitHub ActionsのCronスケジュールを設定する際、UTC（世界標準時）への変換と、Renderが15分でスリープする仕様を考慮し、通知予定時刻の5分前にピンポイントで発火させる設計にしました。今後はこの基盤を用いて、実際の通知ロジック（Job）の実装を進めていきます。