### PR TITLE
通知関連の調整・バグ修正

### DIFF
--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -2,16 +2,51 @@ name: Wake up Render Service
 
 on:
   schedule:
+    # ── 朝7時通知の準備 ──
     # 21:55 (UTC) = 日本時間 6:55 (7:00の通知用)
-    # 10:55 (UTC) = 日本時間 19:55 (20:00の通知用)
-    - cron: '55 10,21 * * *'
-  workflow_dispatch: # 手動で実行するためのボタンをGitHub上に表示させます
+    - cron: '55 21 * * *'
 
+    # ── 夜20時通知（前日・3日前）の準備 ──
+    # 10:55 (UTC) = 日本時間 19:55 (20:00の通知用)
+    - cron: '55 10 * * *'
+    
+  workflow_dispatch: # 手動実行用ボタン
+  
 jobs:
-  ping:
+  ping_and_notify:
     runs-on: ubuntu-latest
     steps:
+      # 1. まず眠っているRenderのサーバーを起こす（コールドスタート対策）
       - name: Send a ping request to Render
         run: |
           curl -s "${{ secrets.RENDER_APP_URL }}" > /dev/null
           echo "Ping sent to Render app successfully."
+
+      # 2. リポジトリのコードをチェックアウト（Rakeを実行するために必要）
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 3. Ruby環境のセットアップ
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2' 
+          bundle-cache: true
+
+      # 4. 【朝7時通知】当日・開始日タスクの実行
+      # ※朝のCron（'55 21 * * *'）で起動した時、または手動実行の時に動く
+      - name: Run Same Day Notifications (7:00 JST)
+        if: github.event.schedule == '55 21 * * *' || github.event_name == 'workflow_dispatch'
+        run: bundle exec rake notification:send_same_day
+        env:
+          RAILS_ENV: production
+          
+      # 5. 【夜20時通知】3日前・前日タスクの実行
+      # ※夜のCron（'55 10 * * *'）で起動した時、または手動実行の時に動く
+      - name: Run Night Notifications (20:00 JST)
+        if: github.event.schedule == '55 10 * * *' || github.event_name == 'workflow_dispatch'
+        run: |
+          bundle exec rake notification:send_3days_prior
+          bundle exec rake notification:send_day_before
+        env:
+          RAILS_ENV: production

--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           ruby-version: '3.2.2' 
           bundle-cache: true
+          
+      - name: Install gems
+        run: bundle install
 
       # 4. 【朝7時通知】当日・開始日タスクの実行
       # ※朝のCron（'55 21 * * *'）で起動した時、または手動実行の時に動く

--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           ruby-version: '3.2.2' 
           bundle-cache: true
-          
+
       - name: Install gems
         run: bundle install
 
@@ -43,7 +43,8 @@ jobs:
         run: bundle exec rake notification:send_same_day
         env:
           RAILS_ENV: production
-          
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+
       # 5. 【夜20時通知】3日前・前日タスクの実行
       # ※夜のCron（'55 10 * * *'）で起動した時、または手動実行の時に動く
       - name: Run Night Notifications (20:00 JST)
@@ -53,3 +54,4 @@ jobs:
           bundle exec rake notification:send_day_before
         env:
           RAILS_ENV: production
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}

--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -45,6 +45,7 @@ jobs:
           RAILS_ENV: production
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
 
       # 5. 【夜20時通知】3日前・前日タスクの実行
       # ※夜のCron（'55 10 * * *'）で起動した時、または手動実行の時に動く
@@ -57,3 +58,4 @@ jobs:
           RAILS_ENV: production
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}

--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2.2' 
-          bundle-cache: true
+          bundler-cache: true
 
       - name: Install gems
         run: bundle install
@@ -44,6 +44,7 @@ jobs:
         env:
           RAILS_ENV: production
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
       # 5. 【夜20時通知】3日前・前日タスクの実行
       # ※夜のCron（'55 10 * * *'）で起動した時、または手動実行の時に動く
@@ -55,3 +56,4 @@ jobs:
         env:
           RAILS_ENV: production
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -5,38 +5,35 @@ class NotificationMailer < ApplicationMailer
     @title = title
     @content = content
 
-    mail(
-      to: user_email,
-      subject: "【FanPocket】新しいお知らせ: #{@title}"
-    )
+    mail(to: user_email,subject: "【FanPocket】新しいお知らせ: #{@title}")
   end
 
   # 3日前通知
   def three_days_ago_notice(user_email, title, content)
     @title = title
     @content = content
-    mail(to: user_email, subject: "【FanPocket】あと3日で締切：#{@title}")
+    mail(to: user_email, subject: "【FanPocket】あと3日で締切です：#{@title}")
   end
 
   # 前日20時通知
   def day_before_notice(user_email, title, content)
     @title = title
     @content = content
-    mail(to: user_email, subject: "【重要】明日締切：#{@title}")
+    mail(to: user_email, subject: "【FanPocket】明日締切です：#{@title}")
   end
 
   # 当日7時通知
   def today_notice(user_email, title, content)
     @title = title
     @content = content
-    mail(to: user_email, subject: "【本日締切】お忘れではありませんか？：#{@title}")
+    mail(to: user_email, subject: "【FanPocket】本日締切です：#{@title}")
   end
 
-  def start_notice(user_email, title, content) # メソッド名をファイル名に合わせる
+  def start_notice(user_email, title, content) 
   @title = title
   @content = content
 
-  mail(to: user_email,subject: "【FanPocket】今日開始です：#{@title}"
+  mail(to: user_email,subject: "【FanPocket】本日開始です：#{@title}"
   )
 end
 end

--- a/app/views/notification_mailer/start_notice.html.erb
+++ b/app/views/notification_mailer/start_notice.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div style="text-align: center; margin-bottom: 32px;">
-    <a href="<%= root_url %>" style="display: inline-block; padding: 12px 36px; font-size: 15px; font-weight: 500; color: #ffffff; background-color: #f17143; text-decoration: none; border-radius: 6px; transition: background-color 0.2s;">
+    <a href="<%= root_url %>" style="display: inline-block; padding: 12px 36px; font-size: 15px; font-weight: 500; color: #ffffff; background-color: #FF66A3; text-decoration: none; border-radius: 6px; transition: background-color 0.2s;">
       詳細を確認する
     </a>
   </div>

--- a/app/views/notification_mailer/today_notice.html.erb
+++ b/app/views/notification_mailer/today_notice.html.erb
@@ -12,7 +12,7 @@
 
   <!-- アクションボタン（手続きページへの導線） -->
   <div style="text-align: center; margin-bottom: 32px;">
-    <a href="<%= root_url %>" style="display: inline-block; padding: 12px 36px; font-size: 15px; font-weight: 500; color: #ffffff; background-color: #f17143; text-decoration: none; border-radius: 6px; transition: background-color 0.2s;">
+    <a href="<%= root_url %>" style="display: inline-block; padding: 12px 36px; font-size: 15px; font-weight: 500; color: #ffffff; background-color: #FF66A3; text-decoration: none; border-radius: 6px; transition: background-color 0.2s;">
       詳細を確認する
     </a>
   </div>

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -12,7 +12,7 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = "「気になっている#{watchlist.title}」の締め切りまであと3日です。忘れないうちにチェックしてみませんか？" 
+        content    = "気になっている「#{watchlist.title}」の締め切りまであと3日です。忘れないうちにチェックしてみませんか？" 
 
         NotificationMailer.three_days_ago_notice(user_email, title, content).deliver_now
         puts "通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
@@ -40,7 +40,7 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = "「気になっている#{watchlist.title}」の締め切りは明日です。大切な予定を見逃さないようにご確認ください。"
+        content    = "気になっている「#{watchlist.title}」の締め切りは明日です。大切な予定を見逃さないようにご確認ください。"
 
         NotificationMailer.day_before_notice(user_email, title, content).deliver_now
         puts "前日通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
@@ -71,7 +71,7 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = "「気になっている#{watchlist.title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
+        content    = "気になっている「#{watchlist.title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
 
         NotificationMailer.today_notice(user_email, title, content).deliver_now
         puts "当日締切通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
@@ -100,7 +100,7 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = "「気になっている#{watchlist.title}」の開始は本日です。詳細をチェックしてみませんか？"
+        content    = "気になっている「#{watchlist.title}」の開始は本日です。詳細をチェックしてみませんか？"
 
         NotificationMailer.start_notice(user_email, title, content).deliver_now
         puts "当日開始通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -9,13 +9,19 @@ namespace :notification do
       user = watchlist.user
       next unless user
       
-      user_email = user.email
-      title      = watchlist.title
-      content    = "「気になっている#{watchlist.title}」の締め切りまであと3日です。忘れないうちにチェックしてみませんか？" 
+      begin
+        user_email = user.email
+        title      = watchlist.title
+        content    = "「気になっている#{watchlist.title}」の締め切りまであと3日です。忘れないうちにチェックしてみませんか？" 
 
-      NotificationMailer.three_days_ago_notice(user_email, title, content).deliver_now
-      
-      puts "通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
+        NotificationMailer.three_days_ago_notice(user_email, title, content).deliver_now
+        puts "通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
+        
+        # 1秒待つ（Resendのレートリミット対策）
+        sleep 1
+      rescue => e
+        puts "【エラー発生】3日前通知失敗 [Watchlist ID: #{watchlist.id}]: #{e.message}"
+      end
     end
 
     puts "--- 3日前通知バッチ処理 終了 ---"
@@ -31,13 +37,19 @@ namespace :notification do
       user = watchlist.user
       next unless user 
 
-      user_email = user.email
-      title      = watchlist.title
-      content    = "「気になっている#{watchlist.title}」の締め切りは明日です。大切な予定を見逃さないようにご確認ください。"
+      begin
+        user_email = user.email
+        title      = watchlist.title
+        content    = "「気になっている#{watchlist.title}」の締め切りは明日です。大切な予定を見逃さないようにご確認ください。"
 
-      NotificationMailer.day_before_notice(user_email, title, content).deliver_now
-      
-      puts "前日通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
+        NotificationMailer.day_before_notice(user_email, title, content).deliver_now
+        puts "前日通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
+        
+        # 1秒待つ（Resendのレートリミット対策）
+        sleep 1
+      rescue => e
+        puts "【エラー発生】前日通知失敗 [Watchlist ID: #{watchlist.id}]: #{e.message}"
+      end
     end
 
     puts "--- 前日通知バッチ処理 終了 ---"
@@ -56,13 +68,19 @@ namespace :notification do
       user = watchlist.user
       next unless user
 
-      user_email = user.email
-      title      = watchlist.title
-      content    = "「気になっている#{watchlist.title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
+      begin
+        user_email = user.email
+        title      = watchlist.title
+        content    = "「気になっている#{watchlist.title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
 
-      NotificationMailer.today_notice(user_email, title, content).deliver_now
-      
-      puts "当日締切通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
+        NotificationMailer.today_notice(user_email, title, content).deliver_now
+        puts "当日締切通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
+        
+        # 1秒待つ（Resendのレートリミット対策）
+        sleep 1
+      rescue => e
+        puts "【エラー発生】当日締切通知失敗 [Watchlist ID: #{watchlist.id}]: #{e.message}"
+      end
     end
 
     puts "--- 当日締切通知バッチ処理 終了 ---"
@@ -79,13 +97,19 @@ namespace :notification do
       user = watchlist.user
       next unless user
 
-      user_email = user.email
-      title      = watchlist.title
-      content    = "「気になっている#{watchlist.title}」の開始は本日です。詳細をチェックしてみませんか？"
+      begin
+        user_email = user.email
+        title      = watchlist.title
+        content    = "「気になっている#{watchlist.title}」の開始は本日です。詳細をチェックしてみませんか？"
 
-      NotificationMailer.start_notice(user_email, title, content).deliver_now
-      
-      puts "当日開始通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
+        NotificationMailer.start_notice(user_email, title, content).deliver_now
+        puts "当日開始通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
+        
+        # 1秒待つ（Resendのレートリミット対策）
+        sleep 1
+      rescue => e
+        puts "【エラー発生】当日開始通知失敗 [Watchlist ID: #{watchlist.id}]: #{e.message}"
+      end
     end
 
     puts "--- 当日開始通知バッチ処理 終了 ---"

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -1,16 +1,17 @@
 namespace :notification do
   desc "締切3日前の未対応タスクがあるユーザーに通知を送る"
   task send_3days_prior: :environment do
-    targets = Watchlist.alert_three_days_prior
+    targets = Watchlist.alert_three_days_prior.includes(:user)
 
     puts "--- 3日前通知バッチ処理 開始 (対象: #{targets.count}件) ---"
 
-    targets.each do |watchlist|
+    targets.find_each do |watchlist|
       user = watchlist.user
+      next unless user
       
       user_email = user.email
       title      = watchlist.title
-      content    = "「#{watchlist.title}」の締め切りまであと3日です。大切な予定を見逃さないようにご確認ください。" 
+      content    = "「気になっている#{watchlist.title}」の締め切りまであと3日です。忘れないうちにチェックしてみませんか？" 
 
       NotificationMailer.three_days_ago_notice(user_email, title, content).deliver_now
       
@@ -26,15 +27,15 @@ namespace :notification do
 
     puts "--- 前日通知バッチ処理 開始 (対象: #{targets.count}件) ---"
 
-    targets.each do |watchlist|
+    targets.find_each do |watchlist|
       user = watchlist.user
       next unless user 
 
       user_email = user.email
       title      = watchlist.title
-      content    = "「#{watchlist.title}」の締め切りが明日に迫っています。大切な予定を見逃さないようにご確認ください。"
+      content    = "「気になっている#{watchlist.title}」の締め切りは明日です。大切な予定を見逃さないようにご確認ください。"
 
-      NotificationMailer.three_days_ago_notice(user_email, title, content).deliver_now
+      NotificationMailer.day_before_notice(user_email, title, content).deliver_now
       
       puts "前日通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
     end
@@ -51,15 +52,15 @@ namespace :notification do
 
     puts "--- 当日締切通知バッチ処理 開始 (対象: #{deadline_targets.count}件) ---"
 
-    deadline_targets.each do |watchlist|
+    deadline_targets.find_each do |watchlist|
       user = watchlist.user
       next unless user
 
       user_email = user.email
       title      = watchlist.title
-      content    = "「#{watchlist.title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
+      content    = "「気になっている#{watchlist.title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
 
-      NotificationMailer.three_days_ago_notice(user_email, title, content).deliver_now
+      NotificationMailer.today_notice(user_email, title, content).deliver_now
       
       puts "当日締切通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
     end
@@ -80,7 +81,7 @@ namespace :notification do
 
       user_email = user.email
       title      = watchlist.title
-      content    = "「#{watchlist.title}」が本日より開始されます！初動を逃さないよう、詳細をご確認ください✨"
+      content    = "「気になっている#{watchlist.title}」の開始は本日です。詳細をチェックしてみませんか？"
 
       NotificationMailer.start_notice(user_email, title, content).deliver_now
       


### PR DESCRIPTION
## 概要
当日開始・締切等の「各種通知バッチ処理」において、本番環境（Render/Neon）での送信エラー（APIレートリミット）を解消し、各種メーラーでのUI崩れ防止とボタン色の変更（#FF66A3）を行いました。

## 背景
GitHub Actionsを用いた通知スケジュールの実行時に、Resendの無料枠制限である「1秒間に2回まで」の上限に達し、`Resend::Error::RateLimitExceededError` が発生して送信が途中でクラッシュしていました。また、ユーザーが大切な予定を見逃さないよう、メールのデザインや文言、ボタン色の視認性を高める必要がありました。

## 変更内容
- **API制限回避と堅牢化（`lib/tasks/notification.rake`）**:
  - ループ処理（`find_each`）内に `sleep 1` を導入し、Resendの秒間リクエスト制限を確実に回避するよう修正。
  - `begin ~ rescue` によるエラーハンドリングを実装。万が一特定のユーザーで送信エラーが発生しても、処理を落とさずに残りの全対象データへ送信を継続する設計に変更。
- **UI・デザインの最適化（`app/views/notification_mailer/` 内の各テンプレート）**:
  - メーラーごとの解釈違いによる型崩れを防ぐため、HTMLメールのスタイルを完全な**インラインスタイル（`style="..."`）**で再構築。
  - 当日通知メール内の「詳細を確認する」ボタンの背景色を、アプリの世界観を引き立てるピンク（`#FF66A3`）に変更。
  - 本文中の「」の位置など、日本語の文字レイアウトをより自然で美しい表現にブラッシュアップ。

## 確認方法
1. GitHub Actions の `Wake up Render Service` ワークフローを手動実行（`workflow_dispatch`）できることを確認。
2. テストデータ（Gmail、キャリアメール等）への一括送信テストを実行し、3件以上のデータに対して送信漏れ（スキップやエラー）が1件も発生せず、Actionsのログが正常終了（Exit code 0）することを確認。
3. 実際に受信したメールボックスにて、以下の3点を確認。
   - 日本語の文字化けがなく、タスク名や日付などの動的変数が正しく埋め込まれていること。
   - ボタンの色が指定のピンク（`#FF66A3`）に変わっており、スマホやPCの画面で崩れがないこと。
   - 朝7時用（当日開始）と夜20時用（前日・3日前）のタスクが、本番環境のスケジュール（CRON設定）に沿って意図通りに動作すること（手動実行時は両方が同時に強制実行される仕様通りの挙動を確認）。

## 影響範囲
- **影響がある機能**: 当日開始・締切等のメール送信バッチ処理全般、メールの見た目
- **影響がないこと**: 一般のユーザー登録や認証、既存の画面表示などのフロントエンド機能には一切影響ありません。

##スクリーンショット
https://i.gyazo.com/4c3563e22c149091a64a8424e837fd56.png
　　↓
https://i.gyazo.com/421302edff375567b43f54c6f6b469fb.png
## 補足
外部API（Resend）の無料枠の仕様（秒間2リクエストまで）を考慮した実装に一番頭を悩ませましたが、`sleep` によるウェイトと `rescue` による安全弁を組み合わせることで、実務のバッチ処理でも耐えうる堅牢なロジックに仕上げることができました。