### PR TITLE
設定画面の作成とログアウト機能の実装

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,7 @@
+class SettingsController < ApplicationController
+
+  before_action :authenticate_user!
+
+  def show
+  end
+end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,0 +1,2 @@
+module SettingsHelper
+end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -12,12 +12,13 @@
     </span>
   <% end %>
 
-  <%# 設定へのリンク（パスは必要に応じて変更してください） %>
-  <%= link_to "#", class: "flex flex-col items-center justify-center transition-all group" do %>
-    <span class="material-symbols-outlined text-3xl text-[#2d6489]/50 group-hover:text-[#2d6489]">
+  <%# 設定へのリンク %>
+  <%= link_to settings_path, class: "flex flex-col items-center justify-center transition-all group" do %>
+    <span class="material-symbols-outlined text-3xl <%= controller_name == 'settings' ? 'text-[#2d6489]' : 'text-[#2d6489]/50' %>"
+          style="<%= 'font-variation-settings: \'FILL\' 1;' if controller_name == 'settings' %>">
       settings
     </span>
-    <span class="text-[10px] font-bold mt-0.5 text-[#2d6489]/50 group-hover:text-[#2d6489]">
+    <span class="text-[10px] font-bold mt-0.5 <%= controller_name == 'settings' ? 'text-[#2d6489]' : 'text-[#2d6489]/50' %>">
       設定
     </span>
   <% end %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Settings#show</h1>
+  <p>Find me in app/views/settings/show.html.erb</p>
+</div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,4 +1,90 @@
-<div>
-  <h1 class="font-bold text-4xl">Settings#show</h1>
-  <p>Find me in app/views/settings/show.html.erb</p>
-</div>
+<header class="bg-white/80 backdrop-blur-sm sticky top-0 z-40 transition-colors border-b border-white">
+  <div class="max-w-full mx-auto px-4 py-3">
+    <div class="flex items-center justify-between w-full">
+      <div class="flex items-center gap-3">
+        <%= link_to root_path, class: "material-symbols-outlined text-primary hover:opacity-70 transition-opacity" do %>
+          arrow_back
+        <% end %>
+        <h1 class="font-headline font-bold text-lg text-primary">これからの予定</h1>
+      </div>
+      <div class="flex items-center gap-2 bg-white/50 px-3 py-1.5 rounded-full border border-white shadow-sm">
+        <%= image_tag "logo.png", class: "w-6 h-6 object-contain", alt: "FanPocket Logo" %>
+        <span class="font-headline font-bold tracking-tight text-primary">FanPocket</span>
+      </div>
+    </div>
+  </div>
+</header>
+
+<main class="px-6 mt-6 space-y-6 max-w-2xl mx-auto pb-28">
+  <div class="mb-4">
+    <h2 class="font-headline font-extrabold text-2xl text-center text-primary">設定</h2>
+    <p class="text-center text-[#4f5052] text-sm mt-1">アプリの使い心地を調整しましょう</p>
+  </div>
+
+  <section>
+    <div class="flex items-center gap-2 mb-3 px-1">
+      <span class="material-symbols-outlined text-primary text-xl">account_circle</span>
+      <h3 class="font-bold text-sm text-on-surface-variant">アカウント</h3>
+    </div>
+    <div class="bg-white rounded-xl p-1 shadow-sm overflow-hidden border border-base-200">
+      <button class="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors text-left" disabled>
+        <div class="flex items-center gap-2">
+          <span class="material-symbols-outlined text-primary/50 text-xl">mail</span>
+          <span class="text-primary font-medium">メールアドレス</span>
+        </div>
+        <div class="flex items-center gap-2 text-on-surface-variant">
+          <span class="text-sm"><%= current_user.email %></span>
+          <span class="material-symbols-outlined text-lg">chevron_right</span>
+        </div>
+      </button>
+      <div class="h-px mx-4 bg-gray-100"></div>
+      <button class="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors text-left" disabled>
+        <div class="flex items-center gap-2">
+          <span class="material-symbols-outlined text-primary/50 text-xl">lock</span>
+          <span class="text-primary font-medium">パスワードの変更</span>
+        </div>
+        <div class="flex items-center gap-2 text-on-surface-variant">
+          <span class="material-symbols-outlined text-on-surface-variant text-lg">chevron_right</span>
+        </div>
+      </button>
+    </div>
+  </section>
+
+  <section>
+    <div class="flex items-center gap-2 mb-3 px-1">
+      <span class="material-symbols-outlined text-primary text-xl">more_horiz</span>
+      <h3 class="font-bold text-sm text-on-surface-variant">その他</h3>
+    </div>
+    <div class="bg-white rounded-xl p-1 shadow-sm overflow-hidden border border-base-200">
+      <button class="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors text-left" disabled>
+        <div class="flex items-center gap-2">
+          <span class="material-symbols-outlined text-primary/50 text-xl">menu_book</span>
+          <span class="text-primary font-medium">使いかたガイド</span>
+        </div>
+        <span class="material-symbols-outlined text-on-surface-variant text-lg">open_in_new</span>
+      </button>
+      <div class="h-px mx-4 bg-gray-100"></div>
+      <button class="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors text-left" disabled>
+        <div class="flex items-center gap-2">
+          <span class="material-symbols-outlined text-primary/50 text-xl">shield_lock</span>
+          <span class="text-primary font-medium">プライバシーポリシー</span>
+        </div>
+        <span class="material-symbols-outlined text-on-surface-variant text-lg">chevron_right</span>
+      </button>
+      <div class="h-px mx-4 bg-gray-100"></div>
+      
+      <%= button_to destroy_user_session_path, 
+                    method: :delete, 
+                    data: { turbo: false }, 
+                    class: "w-full flex items-center justify-between p-4 hover:bg-red-50/30 transition-colors text-left" do %>
+        <div class="flex items-center gap-2">
+          <span class="material-symbols-outlined text-error text-xl">logout</span>
+          <span class="text-error font-semibold">ログアウト</span>
+        </div>
+      <% end %>
+    </div>
+  </section>
+
+</main>
+
+<%= render 'layouts/footer' %>

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -5,7 +5,7 @@
         <%= link_to root_path, class: "material-symbols-outlined text-primary hover:opacity-70 transition-opacity" do %>
           arrow_back
         <% end %>
-        <h1 class="font-headline font-bold text-lg text-primary">一覧に戻る</h1>
+        <h1 class="font-headline font-bold text-lg text-primary">これからの予定</h1>
       </div>
       <div class="flex items-center gap-2 bg-white/50 px-3 py-1.5 rounded-full border border-white shadow-sm">
         <%= image_tag "logo.png", class: "w-6 h-6 object-contain", alt: "FanPocket Logo" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,6 @@ Rails.application.routes.draw do
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 
-  # config/routes.rb
   resources :watchlists, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+  resource :settings, only: [:show]
 end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class SettingsControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get settings_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
ユーザーセッションを安全に終了するための「設定画面（雛形）」を新規作成し、アプリの世界観に馴染むデザインで「ログアウト機能」を実装しました。また、副次的に共通ヘッダーの文言をブラッシュアップしています。

## 背景
ユーザーが安全にアプリの利用を終了したり、別アカウントでログインし直したりできるようにするためにログアウト機能が必要でした。
メイン画面に唐突にログアウトボタンを置くのではなく、ユーザーが任意で開く「設定画面」というワンクッションを挟む動線を確保するために本変更を行いました。

## 変更内容
- **ルーティング・コントローラーの追加**
  - 単数リソース `resource :settings, only: [:show]` を定義し、`/settings` という綺麗なURLでアクセスできるようにしました。
  - `SettingsController` に `before_action :authenticate_user!` を適用し、未ログイン状態での不正アクセスを防止（ログイン画面へリダイレクト）しています。
- **設定画面（UI）の構築**
  - Tailwind CSS と DaisyUI を活用し、スマートフォンの親指でも誤タップしにくい余白を持たせたリスト形式のレイアウト（メールアドレス、使い方ガイド、プライバシーポリシー、ログアウト）を作成しました。
  - 各メニューの左側に Material Symbols のアイコン（`mail`, `menu_book`, `shield_lock`, `logout`）を配置し、縦のラインを揃えて視覚的な統一感を持たせました。
- **ログアウト機能の実装**
  - Rails 7 + Turbo 環境でのセッション破棄の確実性を担保するため、`button_to` に `data: { turbo: false }` を指定してセッションを正しく `DELETE` できるようにしました。
  - ログアウトボタンは「次の画面に遷移する」わけではないため、他の項目にある右矢印をあえて配置しない引き算のデザインにしています。
- **共通ヘッダー・フッターの調整**
  - フッターの設定リンクに `settings_path` を紐付け、現在地が設定画面のときにアイコンがアクティブ（塗りつぶし）になるよう判定ロジックを追加しました。
  - ヘッダーの「一覧に戻る」という表記を、アプリの優しい世界観に合わせて「これからの予定」へとブラッシュアップしました。

## 確認方法
1. ログインした状態で、共通フッターの「設定」をタップし、`/settings`（設定画面）へ正常に遷移すること。
2. 設定画面に現在ログイン中のユーザーのメールアドレスが動的に表示されていること。
3. 「ログアウト」ボタンをタップした際、セッションが正常に破棄され、ログイン画面（またはトップ画面）にリダイレクトされること。
4. ログアウトした状態で直接 `/settings` にURLを入力してアクセスを試みた際、アクセス制限がかかりログイン画面へ押し戻されること。
5. スマートフォン表示において、各メニューやボタンが押しやすいサイズ感になっていること。

## 影響範囲
- **影響がある画面/機能:** 設定画面（新規）、共通ヘッダー・フッター
- **影響がないこと:** 既存のログイン・会員登録機能や、コレクション（一覧）画面のデータ表示自体には影響ありません。

## 補足
- **デザインのこだわり:** ログアウトボタンだけ右矢印をあえて削ることで、他の「別画面に遷移するメニュー」とのアクションの違いを直感的に分かりやすくしました。また、ヘッダーの「これからの予定」への文言変更など、システムライクになりすぎず、自分の大切な予定が優しく収まっている感覚を持てるような言葉選びを意識しています。
- **今後の設計方針:** - 本リリース時にはLINE通知やアプリ・ブラウザ通知の導入を計画しているため、複雑な通知設定のモックはあえて配置せず、まずは「ログアウトができる最小限かつ綺麗な画面」としてシンプルに構築しました。
  - 「使いかたガイド」や「プライバシーポリシー」の項目に関しても、現時点ではリンク先を持たせないモック（非活性）状態として配置しており、今後の各機能の実装・拡張に合わせて、柔軟にコードを付け足していく土台としています。