### PR TITLE
バリデーション強化とエラーメッセージ改善 

### DIFF
--- a/app/javascript/controllers/flatpickr_controller.js
+++ b/app/javascript/controllers/flatpickr_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
       locale: Japanese,
       enableTime: true,
       dateFormat: "Y-m-d H:i",
+      minuteIncrement: 1,
     })
   }
 }

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -7,7 +7,7 @@ class Watchlist < ApplicationRecord
   VALID_URL_REGEX = /\Ahttps?:\/\/[\S]+\z/
   validates :url, allow_blank: true, format: { with: VALID_URL_REGEX }
 
-  validate :end_at_must_be_after_start_at
+  validate :end_at_must_be_future
   
   #3日前通知用
   scope :alert_three_days_prior, -> {
@@ -54,6 +54,12 @@ class Watchlist < ApplicationRecord
   def end_at_must_be_after_start_at
     if start_at.present? && end_at.present? && end_at <= start_at
       errors.add(:end_at, :must_be_after_start_at)
+    end
+  end
+
+  def end_at_must_be_future
+    if end_at.present? && end_at < Time.current
+    errors.add(:end_at, "は未来の日時を選択してください")
     end
   end
 end

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -3,6 +3,11 @@ class Watchlist < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 255 }
   validate :start_at_or_end_at_must_be_present
+
+  VALID_URL_REGEX = /\Ahttps?:\/\/[\S]+\z/
+  validates :url, allow_blank: true, format: { with: VALID_URL_REGEX }
+
+  validate :end_at_must_be_after_start_at
   
   #3日前通知用
   scope :alert_three_days_prior, -> {
@@ -38,9 +43,17 @@ class Watchlist < ApplicationRecord
 
   private
 
+  # 開始時間または締切時間のどちらかは必須
   def start_at_or_end_at_must_be_present
     if start_at.blank? && end_at.blank?
-      errors.add(:base, "開始時間または締切時間のどちらかは入力してください")
+      errors.add(:base, :start_at_or_end_at_blank)
+    end
+  end
+
+  # 両方入力されている場合のみ、日時の矛盾（開始日 < 締切日）をチェック
+  def end_at_must_be_after_start_at
+    if start_at.present? && end_at.present? && end_at <= start_at
+      errors.add(:end_at, :must_be_after_start_at)
     end
   end
 end

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -46,7 +46,7 @@ class Watchlist < ApplicationRecord
   # 開始時間または締切時間のどちらかは必須
   def start_at_or_end_at_must_be_present
     if start_at.blank? && end_at.blank?
-      errors.add(:base, :start_at_or_end_at_blank)
+      errors.add(:base, "開始日時または締切日時のどちらかは入力してください")
     end
   end
 

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,10 +5,10 @@
     <%# アクティブ時は濃い青、非アクティブ時は少し透過させる %>
     <span class="material-symbols-outlined text-3xl <%= action_name == 'index' ? 'text-[#2d6489]' : 'text-[#2d6489]/50' %>" 
           style="<%= 'font-variation-settings: \'FILL\' 1;' if action_name == 'index' %>">
-      style
+    lists
     </span>
     <span class="text-[10px] font-bold mt-0.5 <%= action_name == 'index' ? 'text-[#2d6489]' : 'text-[#2d6489]/50' %>">
-      コレクション
+      これからの予定
     </span>
   <% end %>
 

--- a/app/views/watchlists/_form.html.erb
+++ b/app/views/watchlists/_form.html.erb
@@ -1,13 +1,11 @@
-<%# app/views/watchlists/_form.html.erb %>
-<%= form_with model: watchlist, class: "space-y-10", local: true do |f| %>
+<%= form_with model: watchlist, class: "space-y-10", html: { novalidate: true }, local: true do |f| %>
   <!-- エラーメッセージ表示 -->
-  <% if watchlist.errors.any? %>
-    <div class="bg-error/10 border border-error/20 text-error p-4 rounded-2xl text-sm">
-      <ul class="list-disc list-inside">
-        <% watchlist.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
+  <% if watchlist.errors[:base].any? %>
+    <div class="bg-error/10 border border-error/20 text-error p-4 rounded-2xl text-sm font-medium">
+      <div class="flex items-center gap-2">
+        <span class="material-symbols-outlined text-base">error</span>
+        <%= watchlist.errors[:base].first %>
+      </div>
     </div>
   <% end %>
 
@@ -16,7 +14,16 @@
     <%= f.label :url, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
       <span class="material-symbols-outlined text-lg">link</span>URL
     <% end %>
-    <%= f.url_field :url, class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300", placeholder: "https://example.com/event-page" %>
+    <%# エラーがある場合は ring-error を付与 %>
+    <%= f.url_field :url, class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:url].any?}", placeholder: "https://example.com/event-page" %>
+    <%# 個別エラーメッセージ %>
+   <% if watchlist.errors[:url].any? %>
+      <p class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
+        <span class="material-symbols-outlined text-sm">info</span>
+        <%= watchlist.errors.full_messages_for(:url).first %>
+      </p>
+    <% end %>
+
     <button class="text-primary bg-[#B6E0F3]/50 font-bold text-xs flex items-center gap-1.5 hover:opacity-80 transition-opacity ml-1 bg-accent-soft/40 px-3 py-2 rounded-full active:scale-95" type="button">
       <span class="material-symbols-outlined text-sm">auto_fix</span>タイトルを自動取得する
     </button>
@@ -27,7 +34,15 @@
     <%= f.label :title, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
       <span class="material-symbols-outlined text-lg">title</span>タイトル
     <% end %>
-    <%= f.text_field :title, class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300", placeholder: "グッズ予約、ライブ名など" %>
+    <%= f.text_field :title, class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:title].any?}", placeholder: "グッズ予約、ライブ名など" %>
+    
+    <%# 個別エラーメッセージ %>
+    <% if watchlist.errors[:title].any? %>
+      <p class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
+        <span class="material-symbols-outlined text-sm">info</span>
+        <%= watchlist.errors.full_messages_for(:title).first %>
+      </p>
+    <% end %>
   </div>
 
   <!-- Date Selection Grid -->
@@ -36,14 +51,22 @@
       <%= f.label :start_at, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
         <span class="material-symbols-outlined text-lg">calendar_today</span>開始日時
       <% end %>
-      <%= f.text_field :start_at, data: { controller: "flatpickr" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300", placeholder: "年/月/日 --:--" %>
+      <%= f.text_field :start_at, data: { controller: "flatpickr" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:start_at].any?}", placeholder: "年/月/日 --:--" %>
     </div>
 
     <div class="space-y-3">
       <%= f.label :end_at,  class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
         <span class="material-symbols-outlined text-lg">timer</span>締切日時
       <% end %>
-      <%= f.text_field :end_at, data: { controller: "flatpickr" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300", placeholder: "年/月/日 --:--" %>
+      <%= f.text_field :end_at, data: { controller: "flatpickr" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:end_at].any?}", placeholder: "年/月/日 --:--" %>
+      
+      <%# 個別エラーメッセージ（日時の矛盾など） %>
+      <% if watchlist.errors[:end_at].any? %>
+        <p class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
+          <span class="material-symbols-outlined text-sm">info</span>
+          <%= watchlist.errors.full_messages_for(:end_at).first %>
+        </p>
+      <% end %>
     </div>
   </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,9 +11,8 @@ ja:
     errors:
       models:
         watchlist:
-          attributes:
-            base:
-              start_at_or_end_at_blank: "開始日時または締切日時のどちらかは入力してください"
+          base:
+            start_at_or_end_at_blank: "開始日時または締切日時のどちらかは入力してください"
           attributes:
             title:
               blank: "を入力してください"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,23 @@
+ja:
+  activerecord:
+    models:
+      watchlist: "予定"
+    attributes:
+      watchlist:
+        title: "タイトル"
+        url: "URL"
+        start_at: "開始日時"
+        end_at: "締切日時"
+    errors:
+      models:
+        watchlist:
+          attributes:
+            base:
+              start_at_or_end_at_blank: "開始日時または締切日時のどちらかは入力してください"
+          attributes:
+            title:
+              blank: "を入力してください"
+            url:
+              invalid: "は有効な形式（http/https〜）で入力してください"
+            end_at:
+              must_be_after_start_at: "は開始日時より後の日時を選択してください"


### PR DESCRIPTION
## 概要
ウォッチリスト（予定）登録フォームのバリデーションを強化し、Tailwind CSS / DaisyUI を用いてユーザーに寄り添った親切な日本語エラーメッセージが表示されるようUI/UXを改善しました。あわせて、フッターのナビゲーションやPC環境でのFlatpickrの操作性も調整しています。

## 背景
未入力や不正なURL、ロジックの矛盾した日時が登録されてしまうのを防ぐため。また、エラー発生時にユーザーがどこを修正すべきか直感的に理解できるようにし、アプリの持つ優しい世界観に合わせたエラー表示を実現するため。
（バリデーション強化とエラーメッセージ改善#26）

## 変更内容
- **バリデーションの追加・修正（バックエンド）**
  - タイトルの必須化、URLのフォーマットチェック（`http/https`形式）を実装
  - 日時の矛盾（開始日時 ＞ 締切日時）を防ぐカスタムバリデーションを実装
  - ユースケースを考慮し、**締切日時のみ未来の日時を必須**とし、開始日時は過去でも登録できるよう仕様を調整
- **UI/UXの改善（フロントエンド）**
  - エラー発生時、各入力欄の近くにアイコン付きの赤文字で個別メッセージを表示（Tailwind CSS / DaisyUI）
  - フォーム（`form_with`）に `html: { novalidate: true }` を追加し、ブラウザ標準のお節介なポップアップを無効化してRails側の優しいデザインのエラー表示に統一
  - `ja.yml` から不要になった `base` 翻訳定義を削除しコードをクリーンアップ
- **その他微調整**
  - フッターのナビゲーションアイコンを `style` から `lists` に変更し、文言を『これからの予定』にアップデート（PCで文字崩れがないよう10pxで配置）
  - PC環境において、Flatpickrで分を選択する際にデフォルトの5分単位ではなく、スマホ（iOS）と同様に**1分単位**で直感的に指定できるよう `minuteIncrement: 1` を追加

## 確認方法
1. 予定の追加画面（`watchlists/new`）を開きます。
2. **未入力テスト:** タイトルを空欄のまま保存ボタンを押し、入力欄の下に「タイトルを入力してください」と表示されることを確認します。
3. **URL形式テスト:** URL欄に「a」とだけ入力して保存ボタンを押し、ブラウザのポップアップが出ずに「URLは有効な形式（http/https〜）で入力してください」と表示されることを確認します。
4. **日時矛盾テスト:** 開始日時に「明日」、締切日時に「今日」を設定して保存ボタンを押し、締切日時の下に「開始日時より後の日時を選択してください」と表示されることを確認します。
5. **過去・未来テスト:** 開始日時に「昨日（過去）」、締切日時に「明日（未来）」を入力して保存ボタンを押し、エラーなく正常に登録できることを確認します。また、締切日時のみを「昨日」にすると「未来の日時を選択してください」とエラーが出ることを確認します。
6. **Flatpickrテスト:** PC環境で時間選択を開き、分が1分刻みでカチカチと選択できることを確認します。
7. **フッターテスト:** フッターのアイコンが三本線（`lists`）になり、『これからの予定』という文言が綺麗に収まっていることを確認します。

## 影響範囲
- 予定の登録・編集画面（`watchlists` 関連フォーム）
- アプリ共通のフッター

## スクリーンショット
すべて空の状態の場合のエラー表示：https://i.gyazo.com/3af4174cad816fa770bd1a42d3f1a13e.png
URLエラー、締め切りを「過去」にした際のエラー表示：https://i.gyazo.com/f197e8dbc89c013578ad5d5b912e8429.png
開始日時に「明日」、締切日時に「今日」だった場合のエラー表示:https://i.gyazo.com/50281d859a99e47828876b1b4b7a1277.png

flatpikr：https://i.gyazo.com/bdab95840f62b4522449079112166519.png
フッター：https://i.gyazo.com/0aca5bb15bb1daba85089d967a2c4686.png

## 補足
- **悩んだ点:** 最初はベースエラーのメッセージを `ja.yml` で管理しようと試みましたが、モデル側の `errors.add(:base, ...)` の仕様により探索パスが複雑化し、`Translation missing` になる問題が発生しました。確実性とコードのシンプルさを重視し、モデル側に直接日本語のメッセージを記述する形へとリファクタリングを行いました。