### PR TITLE
未ログイン時のログイン画面初回エラー非表示化

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ FanPocketは、公式X（旧Twitter）やWebサイトで溢れるチケット先
 
 | ログイン画面 | マイページ (スケジュール管理) |
 | :---: | :---: |
-| <img src="https://i.gyazo.com/c3f210d841ba633a899996db75830b50.png" width="100%" alt="ログイン画面"> | <img src="https://i.gyazo.com/c708ea49a27b33fd40b2ba30ac14b7f5.png" width="100%" alt="マイページ画面"> |
+| <img src="https://i.gyazo.com/c3f210d841ba633a899996db75830b50.png" width="100%" alt="ログイン画面"> | <img src="https://i.gyazo.com/7f6bb7be03639c62c3235efc1377c8ed.png" width="100%" alt="マイページ画面"> |
 | *Tailwind CSS × DaisyUIによる、どのジャンルでも使いやすいクリーンなUI* | *視覚的ノイズを削ぎ落とし、開始・締切のタイミングがひと目でわかるレイアウト* |
 
 ---

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,10 @@
+# app/controllers/users/sessions_controller.rb
+class Users::SessionsController < Devise::SessionsController
+  def new
+    # Deviseが設定する「ログインしてください」の文言と一致する場合のみ、初回アラートを消去
+    if flash[:alert] == I18n.t('devise.failure.unauthenticated')
+      flash.delete(:alert)
+    end
+    super
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :user, controllers: {
+    sessions: 'users/sessions'
+  }
+
   root "watchlists#index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
## 概要
未ログイン状態でログイン画面に初回アクセスした際、Deviseの自動生成するフラッシュアラート（「ログインもしくはアカウント登録してください。」）が表示されないようにUXを改善しました。あわせて、README内の切れていた画像リンクを修正しました。

## 背景
セッションがない状態でログイン必須のページにアクセスしたり、直接ログインページを開いたりした際、いきなり赤いアラートで警告されるのはユーザーに不親切な印象を与えてしまうため、初回アクセス時はすっきりと落ち着いた状態の画面を表示したいという背景から対応を行いました。

## 変更内容
- **`Users::SessionsController` を新しく作成（継承）**
  - `new` アクション（ログイン画面表示時）において、未ログイン時のリダイレクトによるフラッシュエラー（`devise.failure.unauthenticated`）をピンポイントで消去（`flash.delete(:alert)`）する処理を追加しました。
- **`config/routes.rb` の修正**
  - Deviseのセッション管理に、新しく作成したカスタムコントローラを使用するようにルーティングを設定しました。
- **`README.md` の修正**
  - リンク切れになっていた画像のパスを、正しいリンクに修正しました。

## 確認方法
1. 一度ログアウト状態（またはシークレットウインドウなど）にする。
2. ログイン画面（`/users/sign_in`）へ初めてアクセスした際、画面上部に「ログインもしくはアカウント登録してください」という赤いアラートが表示されないことを確認。
3. ログイン画面で、メールアドレスやパスワードをわざと間違えて送信した際、正しく認証エラー（「メールアドレスまたはパスワードが違います」など）が画面に表示されることを確認。
4. READMEの画像が正しく表示されていることを確認。

## 影響範囲
- **影響がある画面/機能**
  - ログイン画面（`/users/sign_in`）の初回表示時
- **影響がないこと**
  - 認証失敗時のエラー表示（パスワード間違いなどのエラー表示機能は壊していません）

## スクリーンショット
【訂正前】
<img src="https://i.gyazo.com/50e61ca9be84fe05b5ea8ed04ee941ac.png" width="100%" alt="訂正前のログイン画面" >

【訂正後】
<img src="https://i.gyazo.com/c3f210d841ba633a899996db75830b50.png" width="100%" alt="訂正後のログイン画面" >

## 補足
今回は `ApplicationController` 全体に影響が出る共通フィルターではなく、ログイン画面の表示を担当する `SessionsController#new` をピンポイントで拡張することで、他の認証ロジックを壊さない安全な実装を選択しました。