### PR TITLE
全体のバグ修正と本番環境（Render）での最終動作確認

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  before_action :set_cache_buster
 
   private
 
@@ -11,5 +12,11 @@ class ApplicationController < ActionController::Base
   # サインアップ後のリダイレクト先を指定
   def after_sign_up_path_for(resource)
     root_path
+  end
+
+  def set_cache_buster
+    response.headers["Cache-Control"] = "no-cache, no-store, max-age=0, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 end

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -7,6 +7,7 @@ class Watchlist < ApplicationRecord
   VALID_URL_REGEX = /\Ahttps?:\/\/[\S]+\z/
   validates :url, allow_blank: true, format: { with: VALID_URL_REGEX }
 
+  validate :start_at_must_be_future
   validate :end_at_must_be_future
   
   #3日前通知用
@@ -57,9 +58,15 @@ class Watchlist < ApplicationRecord
     end
   end
 
+  def start_at_must_be_future
+    if start_at.present? && start_at < Time.current
+      errors.add(:start_at, "は未来の日時を選択してください")
+    end
+  end
+
   def end_at_must_be_future
     if end_at.present? && end_at < Time.current
-    errors.add(:end_at, "は未来の日時を選択してください")
+      errors.add(:end_at, "は未来の日時を選択してください")
     end
   end
 end

--- a/app/views/watchlists/_form.html.erb
+++ b/app/views/watchlists/_form.html.erb
@@ -52,6 +52,13 @@
         <span class="material-symbols-outlined text-lg">calendar_today</span>開始日時
       <% end %>
       <%= f.text_field :start_at, data: { controller: "flatpickr" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:start_at].any?}", placeholder: "年/月/日 --:--" %>
+
+      <% if watchlist.errors[:start_at].any? %>
+        <p class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
+          <span class="material-symbols-outlined text-sm">info</span>
+          <%= watchlist.errors.full_messages_for(:start_at).first %>
+        </p>
+      <% end %>
     </div>
 
     <div class="space-y-3">

--- a/app/views/watchlists/_watchlist_card.html.erb
+++ b/app/views/watchlists/_watchlist_card.html.erb
@@ -5,7 +5,7 @@
         <%= watchlist.start_at&.strftime("%Y.%m.%d %H:%M") %>
       </p>
       <h3 class="font-headline font-bold text-lg text-on-surface leading-tight">
-        <%= watchlist.title %>
+        <%= truncate(watchlist.title, length: 30, separator: ' ') %>
       </h3>
     </div>
     

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -24,7 +24,7 @@
   <!-- Title Section -->
   <section class="bg-white p-8 rounded-3xl puffy-shadow relative overflow-hidden border-l-[12px] <%= ( @watchlist.end_at && @watchlist.end_at < Time.current ) ? 'border-gray-300' : 'border-[#B6E0F3]' %>">
     <h2 class="font-headline font-extrabold text-3xl text-on-surface leading-tight tracking-tight relative z-10">
-      <%= @watchlist.title %>
+      <%= truncate(@watchlist.title, length: 30, separator: ' ') %>
     </h2>
     <div class="absolute pointer-events-none select-none z-0" style="bottom: 0; right: 0; width: 100%; height: 100%; overflow: hidden;">
       <span class="material-symbols-outlined" style="font-size: 160px; line-height: 1; position: absolute; bottom: -25px; right: -20px; opacity: 0.05; font-variation-settings: 'wght' 100;">


### PR DESCRIPTION
## 概要
MVPリリース直前に向けた、セキュリティ強化（ブラウザキャッシュ対策）、不正な日付のバリデーション実装、および一覧・詳細画面でのタイトル表示崩れ（文字数制限等）の修正。

## 背景
MVPリリース（公開）にあたり、ユーザー目線でのイレギュラー操作やセキュリティ脆弱性を防ぐため。
具体的には、ログアウト後にブラウザバックでメールアドレス（個人情報）が表示されてしまう問題の解決、GAS（通知システム）側での日付計算エラーを防ぐための過去日付ブロック、および長い文字列が入力された際のスマホ画面等でのレイアウト崩れを解消し、リリース可能な品質を満たすために実施。

## 変更内容
- **セキュリティ（キャッシュ対策）**: `ApplicationController` に `set_cache_buster` メソッドを追加し、認証必須ページでのブラウザの履歴キャッシュ（bfcache）を禁止。ログアウト後のブラウザバックで個人情報（メールアドレス）が残るのを防止。
- **バリデーション強化**: `Watchlist` モデルにカスタムバリデーションを追加。「開始日が過去（昨日以前）」「締切日が開始日より前」のデータ登録をフロント（Rails側）で確実に弾くよう変更。
- **UI/UX表示崩れ修正**: 
  - 一覧画面（カードUI）でタイトルが長すぎる場合、右側のバッジを圧迫しないよう Rails の `truncate` メソッドを使用して適切に文字列を省略（…）表示するよう修正。
  - 詳細画面（show）でも長いタイトルによる突き抜け・レイアウト崩れが起きないよう同様の対策を実施。

## 確認方法
1. **キャッシュテスト**: ログイン状態でマイページ等を開き、ログアウトを実行。その後ブラウザの「戻る」ボタンを押した際、画面がキャッシュ表示されずログイン画面にリダイレクト（ガード）されることを確認。
2. **日付テスト**: データの新規登録時、「昨日以前の日付」や「開始日より前の締切日」を入力した際に、500エラーにならず適切なバリデーションメッセージが表示されて保存がブロックされることを確認。
3. **UIテスト**: タイトルに非常に長い文字列を入力し、一覧画面のカードUIおよび詳細画面で右側の要素を押し潰したり画面外へ突き抜けたりせず、綺麗に収まっている（省略されている）ことを確認。

## 影響範囲
- 影響がある画面/機能: アプリ全体の認証必須ページ、Watchlistの登録・編集機能、一覧画面、詳細画面
- 影響がないこと: 既存の通知インフラ（GAS）側のロジック自体には影響ありません（むしろ不正データが届かなくなるため、安全性が向上します）。

## 補足
- タイトルの表示崩れ対策において、当初はTailwind CSSの `truncate` や `min-w-0` での制御を試みましたが、外側コンテナのレスポンシブ挙動との兼ね合いで完全に収まりきらなかったため、より確実かつ軽量にサーバーサイドで文字数を制御できるRailsの `truncate` メソッド（Ruby側での制限）へアプローチを切り替えて解決しました。