### PR TITLE
一覧の表示順の変更及び開始バッチの表示追加

### DIFF
--- a/app/controllers/watchlists_controller.rb
+++ b/app/controllers/watchlists_controller.rb
@@ -3,13 +3,21 @@ class WatchlistsController < ApplicationController
   before_action :set_watchlist, only: [:show, :edit, :update]
 
  def index
-    # 1. 「これからの予定」：まだ完了していなくて（is_done: false）、終了日時が未来、または未設定のもの
+    # 1. 「これからの予定」
+    # SQL内で、開始日が過去(現在時刻より前)ならend_atを、未来ならLEAST(start_at, end_at)を基準にする
+    target_date_sql = <<~SQL
+      CASE 
+        WHEN start_at < '#{Time.current.to_fs(:db)}' THEN COALESCE(end_at, start_at)
+        ELSE LEAST(start_at, COALESCE(end_at, start_at))
+      END ASC
+    SQL
+
     @future_watchlists = current_user.watchlists
                                      .where(is_done: false)
                                      .where("end_at >= ? OR end_at IS NULL", Time.current)
-                                     .order(start_at: :asc)
+                                     .order(Arel.sql(target_date_sql))
 
-    # 2. 「これまでの足跡」：すでに完了している（is_done: true）か、または終了日時が過去のもの
+    # 2. 「これまでの足跡」
     @past_watchlists = current_user.watchlists
                                    .where(is_done: true)
                                    .or(current_user.watchlists.where("end_at < ?", Time.current))

--- a/app/views/watchlists/_watchlist_card.html.erb
+++ b/app/views/watchlists/_watchlist_card.html.erb
@@ -9,28 +9,43 @@
       </h3>
     </div>
     
-    <div class="flex flex-col items-end gap-2 <%= 'opacity-60' if is_past || watchlist.is_done? %>">
+    <div class="flex flex-col items-end justify-center min-h-[48px] gap-2 <%= 'opacity-60' if is_past || watchlist.is_done? %>">
       <% if watchlist.is_done? %>
         <%# 1. 対応済みの場合 %>
-        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic">対応済み</span>
-      <% elsif !is_past && watchlist.end_at.present? && watchlist.end_at >= Time.current %>
-        <%# 2. これからの予定（まだ期限が来ていない） %>
-        <% days_left = (watchlist.end_at.to_date - Date.today).to_i %>
-        <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
-          <%= days_left <= 0 ? "本日締切" : "あと#{days_left}日" %>
-        </span>
+        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic mb-1">対応済み</span>
+
+      <% elsif !is_past %>
+        <%# 2. これからの予定（開始前、または締切前） %>
+        <% if watchlist.start_at.present? && watchlist.start_at > Time.current %>
+          <% days_to_start = (watchlist.start_at.to_date - Date.today).to_i %>
+          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
+            <%= days_to_start <= 0 ? "本日開始！" : "開始まであと#{days_to_start}日" %>
+          </span>
+        <% elsif watchlist.end_at.present? && watchlist.end_at >= Time.current %>
+          <% days_left = (watchlist.end_at.to_date - Date.today).to_i %>
+          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
+            <%= days_left <= 0 ? "締切当日！" : "締切まであと#{days_left}日" %>
+          </span>
+        <% end %>
+
       <% elsif watchlist.end_at.present? && watchlist.end_at < Time.current %>
         <%# 3. 未完了のまま期限が過ぎた場合（受付終了） %>
-        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic">受付終了</span>
+        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic mb-1">受付終了</span>
       <% elsif is_past %>
         <%# 4. それ以外の過去の予定（思い出） %>
-        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic">思い出</span>
+        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic mb-1">思い出</span>
       <% end %>
 
-      <%# アイコンの切り替え（足跡セクション、または対応済みならグレーの箱になります） %>
-      <span class="material-symbols-outlined <%= (is_past || watchlist.is_done?) ? 'text-gray-300' : 'text-[#B6E0F3]' %>">
-        <%= (is_past || watchlist.is_done?) ? 'inventory_2' : 'push_pin' %>
-      </span>
+      <%# 📌 アイコンの出し分けと位置調整を完全に分離 %>
+      <% if is_past || watchlist.is_done? || (watchlist.end_at.present? && watchlist.end_at < Time.current) %>
+        <%# 【過去・完了・受付終了】は一括して「箱アイコン」をバッジの下に表示 %>
+        <span class="material-symbols-outlined text-gray-300">inventory_2</span>
+      <% else %>
+        <%# 【現在・未来の未完了タスク】のみ、右上ピンを配置 %>
+        <span class="material-symbols-outlined absolute top-4 right-4 text-xs text-[#B6E0F3]">
+          push_pin
+        </span>
+      <% end %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
 ## 概要
スケジュール一覧（マイページやダッシュボード）の表示順を「開始日時」固定から「開始・締切を考慮した直近順（混合タイムライン）」に変更し、それに合わせて各種バッジの表示およびカードUIの崩れを修正しました。

## 背景
これまでは開始日時（start_at）順で固定されていたため、開始日は遠いものの「締切日（end_at）が直前に迫っている」という最重要タスクが埋もれてしまうリスクがありました。ユーザーが「次に何をすべきか」を直感的に把握できるよう、より利用シーンに則した並び順に改善する必要がありました。

## 変更内容
- **コントローラー層 (`WatchlistsController`)**
  - SQLの `CASE` 文と `LEAST` 関数を使用し、「開始前なら直近（開始 or 締切の近い方）」「開始後は締切日時」を基準とした動的な混合ソートロジックへ変更。
- **ビュー層 (`_watchlist_card.html.erb`)**
  - 「締め切りまであと◯日」に加え、開始前のタスクに対して「開始まであと◯日」のバッジが表示されるようにロジックを追加（既存バッジと色を統一）。
  - 未完了タスクのピン留めアイコンをカード右上（`absolute`）に固定し、付箋風の可愛いデザインへ改善。
  - 「対応済み」「受付終了」などの過去タスクにおいて、高さの消失によるカードの縦潰れや、文字とアイコンの重複が発生していた表示崩れを `min-h` および `justify-center` を用いて綺麗に整列するよう修正。

## 確認方法
1. 開始前のタスク、開始済みで締切待ちのタスク、締切未設定のタスク、過去のタスク（対応済み・受付終了）をそれぞれ複数作成する。
2. 一覧画面で、仕様（「開始 $\le$ 締切」）を満たした状態で「今、直近でアクションを起こすべきタスク」がタイムライン形式で上から綺麗に並んでいることを確認。
3. 開始前のタスクに「開始まであと◯日」、期間中のタスクに「締め切りまであと◯日」と正しく表示されていることを確認。
4. 「対応済み」「受付終了」のカードが縦に潰れたり、アイコンと文字が被ったりせずに均等な高さで整列していることを確認。

## 影響範囲
- スケジュール一覧画面（マイページ、ダッシュボード等）
- 予定カードのコンポーネント
※データの作成・編集・削除機能自体への影響はありません。

## スクリーンショット
| 修正後のUIイメージ（混合タイムライン・UI崩れ修正後） |
| --- |
| <img src="https://i.gyazo.com/250d6e48243a2710e47477f75ea9552d.png" width="100%"> |

## 補足
- データベースの種類によって `LEAST` や `COALESCE` の挙動が変わる可能性があるため、今回は開発環境と本番環境（PostgreSQL想定）の双方で安全に動作するSQL構文を採用しました。
- バッジの色分け（開始前と締切前で色を変えるなど）は、全体のデザインバランスを考慮し本リリースのタイミングで別途行う予定です。 |