### PR TITLE
プライバシーポリシー・利用規約ページの設置

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:terms, :privacy]
+  skip_before_action :authenticate_user!, only: %i[terms privacy]
 
   def terms; end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,8 +1,7 @@
-# frozen_string_literal: true
-
 class StaticPagesController < ApplicationController
-  # topアクションのみ、ログインなしでもアクセス可能にする
-  skip_before_action :authenticate_user!, only: [:top]
+  skip_before_action :authenticate_user!, only: [:terms, :privacy]
 
-  def top; end
+  def terms; end
+
+  def privacy; end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -77,10 +77,15 @@
     </main>
 
     <!-- Footer Actions -->
-    <footer class="flex flex-col items-center space-y-8 pt-4">
+    <footer class="flex flex-col items-center space-y-4 pt-4 pb-8">
       <div class="flex flex-col sm:flex-row items-center sm:space-x-2 space-y-1 sm:space-y-0 text-center">
         <span class="text-gray-500 text-sm">アカウントをお持ちでないですか？</span>
         <%= link_to "新規登録はこちら", new_registration_path(resource_name), class: "text-primary font-bold text-sm hover:underline decoration-2 underline-offset-4" %>
+      </div>
+      <%# classを1つに統合し、横並びや間隔を調整しやすいように調整 %>
+      <div class="flex gap-4">
+        <%= link_to '利用規約', terms_path, class: "link link-hover text-primary font-bold text-sm hover:underline decoration-2 underline-offset-4" %>
+        <%= link_to 'プライバシーポリシー', privacy_path, class: "link link-hover text-primary font-bold text-sm hover:underline decoration-2 underline-offset-4" %>
       </div>
     </footer>
   </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -56,23 +56,40 @@
       <h3 class="font-bold text-sm text-on-surface-variant">その他</h3>
     </div>
     <div class="bg-white rounded-xl p-1 shadow-sm overflow-hidden border border-base-200">
-      <button class="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors text-left" disabled>
-        <div class="flex items-center gap-2">
-          <span class="material-symbols-outlined text-primary/50 text-xl">menu_book</span>
-          <span class="text-primary font-medium">使いかたガイド</span>
-        </div>
-        <span class="material-symbols-outlined text-on-surface-variant text-lg">open_in_new</span>
-      </button>
-      <div class="h-px mx-4 bg-gray-100"></div>
-      <button class="w-full flex items-center justify-between p-4 hover:bg-gray-50 transition-colors text-left" disabled>
-        <div class="flex items-center gap-2">
-          <span class="material-symbols-outlined text-primary/50 text-xl">shield_lock</span>
-          <span class="text-primary font-medium">プライバシーポリシー</span>
-        </div>
-        <span class="material-symbols-outlined text-on-surface-variant text-lg">chevron_right</span>
-      </button>
-      <div class="h-px mx-4 bg-gray-100"></div>
-      
+      <%# 1. 使いかたガイド %>
+      <div class="border-b border-gray-100 mx-4">
+        <button class="w-full flex items-center justify-between py-4 hover:bg-gray-50 transition-colors text-left" disabled>
+          <div class="flex items-center gap-2">
+            <span class="material-symbols-outlined text-primary/50 text-xl">menu_book</span>
+            <span class="text-primary font-medium">使いかたガイド</span>
+          </div>
+          <span class="material-symbols-outlined text-on-surface-variant text-lg">open_in_new</span>
+        </button>
+      </div>
+
+      <%# 2. 利用規約（blockを追加し、外側をborderを持つdivで包む） %>
+      <div class="border-b border-gray-100 mx-4">
+        <%= link_to terms_path, class: "block w-full flex items-center justify-between py-4 hover:bg-gray-50 transition-colors text-left" do %>
+          <div class="flex items-center gap-2">
+            <span class="material-symbols-outlined text-primary/50 text-xl">description</span>
+            <span class="text-primary font-medium">利用規約</span>
+          </div>
+          <span class="material-symbols-outlined text-on-surface-variant text-lg">chevron_right</span>
+        <% end %>
+      </div>
+
+      <%# 3. プライバシーポリシー（blockを追加し、外側をborderを持つdivで包む） %>
+      <div class="border-b border-gray-100 mx-4">
+        <%= link_to privacy_path, class: "block w-full flex items-center justify-between py-4 hover:bg-gray-50 transition-colors text-left" do %>
+          <div class="flex items-center gap-2">
+            <span class="material-symbols-outlined text-primary/50 text-xl">shield_lock</span>
+            <span class="text-primary font-medium">プライバシーポリシー</span>
+          </div>
+          <span class="material-symbols-outlined text-on-surface-variant text-lg">chevron_right</span>
+        <% end %>
+      </div>
+  
+      <%# 4. ログアウト（一番下なので線は不要） %>
       <%= button_to destroy_user_session_path, 
                     method: :delete, 
                     data: { turbo: false }, 

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -55,7 +55,7 @@
   </div>
   <%# --- ページの終わりに追加する戻るボタン --- %>
   <div class="mt-12 flex justify-center">
-    <button onclick="history.back()" class="text-primary font-bold text-lg gap-2 px-6">
+    <button onclick="history.back()" class="text-primary font-bold text-lg gap-2 px-6 hover:opacity-70 transition-opacity">
       もどる
     </button>
   </div>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,4 +1,62 @@
-<div class="container mx-auto p-8">
-  <h1 class="text-2xl font-bold mb-4">利用規約（テスト表示）</h1>
-  <p>ここに利用規約の文章が入ります。</p>
-</div>
+<main class="px-6 py-12 max-w-3xl mx-auto pb-28 text-base-content leading-relaxed">
+  <div class="mb-10 text-center">
+    <h1 class="font-headline font-extrabold text-3xl text-primary mb-2">プライバシーポリシー</h1>
+    <p class="text-sm text-gray-500">最終更新日: 2026年6月23日</p>
+  </div>
+
+  <div class="space-y-8 bg-white p-6 md:p-8 rounded-2xl shadow-sm border border-base-200 text-sm md:text-base">
+    <p>
+      FanPocket（以下，「運営者」といいます。）は，本ウェブサイト上で提供するサービス「[サービス名]」（以下，「本サービス」といいます。）における，ユーザーの個人情報の取扱いについて，以下のとおりプライバシーポリシー（以下，「本ポリシー」といいます。）を定めます。
+    </p>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第1条（個人情報の収集方法）</h2>
+      <p>本サービスは、ユーザーが利用登録をする際に氏名、メールアドレスなどの個人情報をお尋ねすることがあります。また、外部サービス（Google等のSNSアカウント）との連携を許可した場合、当該外部サービスからユーザーの識別子などの情報を取得することがあります。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第2条（個人情報を収集・利用する目的）</h2>
+      <p>運営者が個人情報を収集・利用する目的は，以下のとおりです。</p>
+      <ul class="list-disc pl-5 space-y-1">
+        <li>本サービスの提供・運営のため</li>
+        <li>ユーザーからのお問い合わせに回答するため（本人確認を行うことを含む）</li>
+        <li>ユーザーが利用中のサービスの新機能，更新情報等をお届けするため</li>
+        <li>メンテナンス，重要なお知らせなどに関わる必要に応じたご連絡のため</li>
+        <li>利用規約に違反したユーザーや，不正・不当な目的でサービスを利用しようとするユーザーの特定をおこない，利用を断るため</li>
+        <li>ユーザー自身が登録情報の閲覧や変更，削除，利用状況の閲覧を行えるようにするため</li>
+      </ul>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第3条（個人情報の第三者提供）</h2>
+      <p>運営者は，次に掲げる場合を除いて，あらかじめユーザーの同意を得ることなく，第三者に個人情報を提供することはありません。ただし，個人情報保護法その他の法令で認められる場合を除きます。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第4条（個人情報の開示・訂正・削除）</h2>
+      <p>ユーザーは、本サービスの登録画面からいつでも自身の登録情報を確認・変更・削除することができます。また、運営者に対して直接データの開示や削除を請求する場合、運営者は本人確認を行った上で、合理的な期間内にこれに対応します。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第5条（アクセス解析ツール等の利用）</h2>
+      <p>本サービスでは、クッキー（Cookie）を利用して、ユーザーのアクセス情報の収集やログイン状態の保持を行うことがあります。クッキーはユーザーのブラウザを識別するものであり、特定の個人を直接識別するものではありません。ユーザーはブラウザの設定によりクッキーの受け入れを拒否することができます。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第6条（プライバシーポリシーの変更）</h2>
+      <p>1. 本ポリシーの内容は，法令その他本ポリシーに別段の定めのある事項を除いて，ユーザーに通知することなく，変更することができるものとします。</p>
+      <p>2. 運営者が別途定める場合を除いて，変更後のプライバシーポリシーは，本ウェブサイトに掲載したときから効力を生じるものとします。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第7条</h2>
+      <p>本ポリシーに関するお問い合わせは，本サービス内のお問い合わせフォーム、または運営者の指定する連絡先までお願いいたします。</p>
+    </section>
+  </div>
+  <%# --- ページの終わりに追加する戻るボタン --- %>
+  <div class="mt-12 flex justify-center">
+    <button onclick="history.back()" class="text-primary font-bold text-lg gap-2 px-6">
+      もどる
+    </button>
+  </div>
+</main>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,4 @@
+<div class="container mx-auto p-8">
+  <h1 class="text-2xl font-bold mb-4">利用規約（テスト表示）</h1>
+  <p>ここに利用規約の文章が入ります。</p>
+</div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -78,7 +78,7 @@
   </div>
   <%# --- ページの終わりに追加する戻るボタン --- %>
   <div class="mt-12 flex justify-center">
-    <button onclick="history.back()" class="text-primary font-bold text-lg gap-2 px-6">
+    <button onclick="history.back()" class="text-primary font-bold text-lg gap-2 px-6 hover:opacity-70 transition-opacity">
       もどる
     </button>
   </div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,4 +1,85 @@
-<div class="container mx-auto p-8">
-  <h1 class="text-2xl font-bold mb-4">プライバシーポリシー（テスト表示）</h1>
-  <p>ここにプライバシーポリシーの文章が入ります。</p>
-</div>
+<main class="px-6 py-12 max-w-3xl mx-auto pb-28 text-base-content leading-relaxed">
+  <div class="mb-10 text-center">
+    <h1 class="font-headline font-extrabold text-3xl text-primary mb-2">利用規約</h1>
+    <p class="text-sm text-gray-500">最終更新日: 2026年6月23日</p>
+  </div>
+
+  <div class="space-y-8 bg-white p-6 md:p-8 rounded-2xl shadow-sm border border-base-200 text-sm md:text-base">
+    <p>
+      この利用規約（以下，「本規約」といいます。）は，FanPocket（以下，「運営者」といいます。）がこのウェブサイト上で提供するサービス（以下，「本サービス」といいます。）の利用条件を定めるものです。ユーザーの皆さまには，本規約に従って本サービスをご利用いただきます。
+    </p>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第1条（適用）</h2>
+      <p>本規約は，ユーザーと運営者との間の本サービスの利用に関わる一切の関係に適用されるものとします。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第2条（利用登録とアカウント管理）</h2>
+      <p>1. 本サービスにおいては，登録希望者が本規約に同意の上，運営者の定める方法によって利用登録を申請し，運営者がこれを承認することによって，利用登録が完了するものとします。</p>
+      <p>2. ユーザーは，自己の責任において，本サービスのログインに使用する外部アカウント（Googleアカウント等）およびパスワード等を適切に管理するものとします。</p>
+      <p>3. ユーザーは，いかなる場合にも，アカウントを第三者に譲渡または貸与することはできません。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第3条（禁止事項）</h2>
+      <p>ユーザーは，本サービスの利用にあたり，以下の行為をしてはなりません。</p>
+      <ul class="list-disc pl-5 space-y-1">
+        <li>法令または公序良俗に違反する行為</li>
+        <li>犯罪行為に関連する行為</li>
+        <li>本サービスに含まれる著作権，商標権その他の知的財産権を侵害する行為</li>
+        <li>当運営者，ほかのユーザー，またはその他第三者のサーバーまたはネットワークの機能を破壊したり，妨害したりする行為</li>
+        <li>本サービスによって得られた情報を商業的に利用する行為</li>
+        <li>運営者のサービスの運営を妨害するおそれのある行為</li>
+        <li>不正アクセスをし，またはこれを試みる行為</li>
+        <li>他のユーザーに関する個人情報等を収集または蓄積する行為</li>
+        <li>他のユーザーに成りすます行為</li>
+        <li>その他，運営者が不適切と判断する行為</li>
+      </ul>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第4条（本サービスの提供の停止等）</h2>
+      <p>運営者は，以下のいずれかの事由があると判断した場合，ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。</p>
+      <ul class="list-disc pl-5 space-y-1">
+        <li>本サービスに係るコンピュータシステムの保守点検または更新を行う場合</li>
+        <li>地震，落雷，火災，停電または天災などの不可抗力により，本サービスの提供が困難となった場合</li>
+        <li>コンピュータまたは通信回線等が事故により停止した場合</li>
+        <li>その他，運営者が本サービスの提供が困難と判断した場合</li>
+      </ul>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第5条（利用制限および登録抹消）</h2>
+      <p>運営者は，ユーザーが本規約のいずれかの条項に違反した場合、事前の通知をすることなく，ユーザーに対して，本サービスの全部もしくは一部の利用を制限し，またはユーザーとしての登録を抹消することができるものとします。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第6条（免責事項）</h2>
+      <p>1. 運営者は，本サービスに事実上または法律上の瑕疵（安全性，信頼性，正確性，完全性，有効性，特定の目的への適合性，セキュリティなどに関する欠陥，エラーやバグ，権利侵害などを含みます。）がないことを明示的にも黙示的にも保証しておりません。</p>
+      <p>2. 運営者は，本サービスに起因してユーザーに生じたあらゆる損害について、運営者の故意又は重過失による場合を除き、一切の責任を負いません。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第7条（サービス内容の変更等）</h2>
+      <p>運営者は，ユーザーへの事前の通知なく、本サービスの内容を変更し、または本サービスの提供を中止することができるものとし，これによってユーザーに生じた損害について一切の責任を負いません。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第8条（利用規約の変更）</h2>
+      <p>運営者は，必要と判断した場合には，ユーザーに通知することなくいつでも本規約を変更することができるものとします。なお，本規約の変更後，本サービスの利用を開始した場合には，当該ユーザーは変更後の規約に同意したものとみなします。</p>
+    </section>
+
+    <section class="space-y-2">
+      <h2 class="font-bold text-lg text-primary border-b pb-1">第9条（準拠法・裁判管轄）</h2>
+      <p>1. 本規約の解釈にあたっては，日本法を準拠法とします。</p>
+      <p>2. 本サービスに関して紛争が生じた場合には，運営者の居住地を管轄する裁判所を専属的合意管轄とします。</p>
+    </section>
+  </div>
+  <%# --- ページの終わりに追加する戻るボタン --- %>
+  <div class="mt-12 flex justify-center">
+    <button onclick="history.back()" class="text-primary font-bold text-lg gap-2 px-6">
+      もどる
+    </button>
+  </div>
+</main>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,4 @@
+<div class="container mx-auto p-8">
+  <h1 class="text-2xl font-bold mb-4">プライバシーポリシー（テスト表示）</h1>
+  <p>ここにプライバシーポリシーの文章が入ります。</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-
+  
+  get 'terms', to: 'static_pages#terms'
+  get 'privacy', to: 'static_pages#privacy'
   # Defines the root path route ("/")
   # root "posts#index"
 


### PR DESCRIPTION
## 概要
本番運用を見据えた法的配慮として、「利用規約」および「プライバシーポリシー」の静的ページを作成し、フッターおよび設定画面からアクセスできるように導線を実装しました。

## 背景
Webサービスを一般公開するにあたり、ユーザーの個人情報の取り扱いや免責事項を明記し、サービスの信頼性と法的安全性を担保するため。また、ポートフォリオ審査において基本要件（法的配慮）を網羅していることを明確に示すためです。
（ここにIssueのリンクを貼る）

## 変更内容
- **ルーティング・コントローラーの追加**: `/terms` と `/privacy` のエンドポイントを設定し、`StaticPagesController` で制御。未ログイン状態でもアクセス可能にするため、ログイン必須フィルターの対象外に設定しました。
- **Viewファイルの作成と文章の実装**: Tailwind CSSを用いてデザインを調整した `terms.html.erb` と `privacy.html.erb` を作成し、文面を配置しました。
- **フッターへの導線追加**: 未ログインのユーザーでもいつでも確認できるよう、共通フッターにリンクを配置しました。
- **設定画面への導線追加**: ログイン中のユーザー用に、設定画面の「その他」セクションにリンクを組み込み、全体のデザイン（線の太さや余白など）に馴染むようUIを調整しました。
- **UXの向上（「もどる」ボタン）**: 各規約ページの最下部に、アプリの世界観に合わせたシンプルなテキスト風の「もどる」ボタンを設置。`history.back()` を用いることで、どの画面から遷移してきても元の画面に自然に戻れる設計にし、かつマウスホバー時に優しく色が変わるよう `hover:opacity-70 transition-opacity` を適用しました。

## 確認方法
1. **未ログイン状態での確認**
   - ログアウトした状態でトップページ等の最下部（フッター）に「利用規約」「プライバシーポリシー」のリンクが表示されていること。
   - それぞれをクリックした際、ログイン画面に弾かれずに各規約ページが正しく表示されること。
2. **ログイン状態での確認**
   - ログイン後、設定画面の「その他」セクションに「利用規約」と「プライバシーポリシー」が均等な区切り線とともに並んでいること。
   - ホバー時に背景色が変わることを確認し、クリックして各ページへ遷移できること。
3. **もどるボタンの確認**
   - 規約ページの最下部にある「もどる」テキストにマウスを乗せた際、ふわっと薄くなること（`opacity-70`）。
   - クリックした際、直前にいた画面（フッターからならトップ等、設定画面からなら設定画面）に正しく戻ること。

## 影響範囲
- 共通フッター
- 設定画面（ログイン時のみ）
- 新規追加ページ（`/terms`, `/privacy`）
※既存の機能やユーザー認証の挙動自体への影響はありません。

## 補足
- リンクタグ（`link_to`）にしたことで発生した、設定画面内の区切り線のわずかな太さのズレを解消するため、要素を包む `div` 側に `border-b` を持たせる構造に変更し、1px未満のレンダリングのブレを防ぎました。
- ボタンのデザインは、ガチガチのボタン枠をあえて使わず、アプリの穏やかな世界観に合わせてシンプルなひらがなの「もどる」テキストリンクを採用しました。