### PR TITLE
Render（本番環境）のアセットエラーの修正

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,7 +2,7 @@
 // Run that command whenever you add a new controller or create them with
 // ./bin/rails generate stimulus controllerName
 
-import { application } from "./application"
+import { application } from "controllers/application"
 
 // Importmap環境でコントローラーを正しく自動ロードする記述
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,14 +4,6 @@
 
 import { application } from "./application"
 
-import FlashController from "./flash_controller"
-application.register("flash", FlashController)
-
-import FlatpickrController from "./flatpickr_controller"
-application.register("flatpickr", FlatpickrController)
-
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
-
-import WatchlistFormController from "./watchlist_form_controller"
-application.register("watchlist-form", WatchlistFormController)
+// Importmap環境でコントローラーを正しく自動ロードする記述
+import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
+eagerLoadControllersFrom("controllers", application)

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,4 +6,5 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin "flatpickr", to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/flatpickr.js"
 pin "flatpickr/dist/l10n/ja.js", to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/l10n/ja.js"
+pin "controllers/application", to: "controllers/application.js"
 pin_all_from "app/javascript/controllers", under: "controllers", preload: true

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,6 +3,8 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = "1.0"
 
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
+Rails.application.config.assets.paths << Rails.root.join("app/javascript")
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 


### PR DESCRIPTION
## 概要
本番環境（Render）において、StimulusコントローラーをはじめとするJavaScriptアセットが正常に読み込めず、`ActionController::RoutingError`（404 Not Found）が発生していた不具合を修正しました。

## 変更内容
本番環境のアセットプリコンパイルとImportmapのパス解決が正しく連携できるよう、以下の修正を行いました。

1. **アセットの検索パス追加** (`config/initializers/assets.rb`)
   - `app/javascript` ディレクトリをRailsのアセットコンパイル対象パスに追加しました。
2. **Importmapのピン留め追加** (`config/importmap.rb`)
   - `controllers/application.js` が本番環境で正しくマッピングされるよう、明示的に `pin` 設定を追加しました。
3. **Stimulusコントローラーのロード方式の最適化** (`app/javascript/controllers/index.js`)
   - 拡張子なしのURLによるルーティングエラーを防ぐため、個別インポート形式から、Importmapと親和性の高い一括自動ロード方式（`eagerLoadControllersFrom`）へ書き換えました。
   - `application` のインポートパスを、相対パス（`./application`）からImportmapの名前付きパス（`"controllers/application"`）に修正し、本番環境のハッシュ値付きURLを正しく解決できるようにしました。

## 確認方法
- [x] Render（本番環境）へのデプロイが正常に完了すること。
- [x] 本番環境のブラウザ開発者ツール（Console）およびRenderのログにおいて、`/assets/controllers/...` に関連する `RoutingError` が完全に解消されていること。
- [x] 本番環境において、追加したフロントエンド機能（フラッシュメッセージの自動消去、日付変更時のリアルタイム警告UI消去など）が意図通りに動作すること。