### PR TITLE
パスワードリセット画面のUI/UX改善 ＆ パスワード表示切り替え（目隠し）機能の実装

### DIFF
--- a/app/javascript/controllers/password_toggle_controller.js
+++ b/app/javascript/controllers/password_toggle_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "input", "icon" ]
+
+  connect() {
+    // 初期状態（パスワード非表示）のアイコンを設定
+    this.updateIcon(false)
+  }
+
+  toggle() {
+    const isPassword = this.inputTarget.type === "password"
+    
+    // inputのtype属性を password ⇄ text で切り替え
+    this.inputTarget.type = isPassword ? "text" : "password"
+    
+    // 状態に合わせてアイコンを切り替え
+    this.updateIcon(!isPassword)
+  }
+
+  updateIcon(visible) {
+    if (visible) {
+      // 目が開いているSVG（パスワード表示中）
+      this.iconTarget.innerHTML = `
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+        </svg>
+      `
+    } else {
+      // 目に斜線が入っているSVG（パスワード非表示中）
+      this.iconTarget.innerHTML = `
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.822 7.822 3 3m-3-3-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
+        </svg>
+      `
+    }
+  }
+}

--- a/app/javascript/controllers/password_toggle_controller.js
+++ b/app/javascript/controllers/password_toggle_controller.js
@@ -4,8 +4,9 @@ export default class extends Controller {
   static targets = [ "input", "icon" ]
 
   connect() {
-    // 初期状態（パスワード非表示）のアイコンを設定
-    this.updateIcon(false)
+    // 初期状態：パスワード非表示（●●●）なので、
+    // 次のアクションとして「目に斜線が入っているSVG（隠す）」を表示するために true を設定
+    this.updateIcon(true)
   }
 
   toggle() {
@@ -20,18 +21,18 @@ export default class extends Controller {
 
   updateIcon(visible) {
     if (visible) {
-      // 目が開いているSVG（パスワード表示中）
+      // 🟢 パスワード非表示（password）のとき：次に「隠す」ための斜線が入った目
+      this.iconTarget.innerHTML = `
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.822 7.822 3 3m-3-3-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
+        </svg>
+      `
+    } else {
+      // 🟢 パスワード表示中（text）のとき：次に「見る」ための普通の目
       this.iconTarget.innerHTML = `
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
           <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-        </svg>
-      `
-    } else {
-      // 目に斜線が入っているSVG（パスワード非表示中）
-      this.iconTarget.innerHTML = `
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.822 7.822 3 3m-3-3-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88" />
         </svg>
       `
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :watchlists, dependent: :destroy
+
+  def send_password_change_notification
+    Devise::Mailer.password_change(self).deliver_now
+  end
 end

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,17 @@
-<p>Hello <%= @resource.email %>!</p>
+<div style="font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif; color: #333333; max-width: 600px; margin: 0 auto; padding: 24px; background-color: #fdfdfd; border: 1px solid #eef0f2; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.02);">
+  
+  <h2 style="font-size: 18px; font-weight: 600; line-height: 1.5; color: #2d3748; margin-bottom: 20px; border-bottom: 1px solid #edf2f7; padding-bottom: 12px;">
+    パスワード変更完了のお知らせ
+  </h2>
+  
+  <div style="font-size: 15px; line-height: 1.7; color: #4a5568; margin-bottom: 32px;">
+    <p>いつも FanPocket をご利用いただきありがとうございます。</p>
+    <p><%= @resource.email %> 様の アカウントのパスワードが正常に変更されました。</p>
+    <p style="margin-top: 16px;">※この変更にお心当たりがない場合は、お手数ですがサポートまでお問い合わせください。</p>
+  </div>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+  <div style="border-top: 1px solid #edf2f7; padding-top: 20px; font-size: 12px; color: #a0aec0; text-align: center; line-height: 1.6;">
+    <p>※このメールは送信専用アドレスから配信されています。ご返信いただけませんのでご了承ください。</p>
+    <p style="margin-top: 12px; font-weight: 500;">&copy; FanPocket</p>
+  </div>
+</div>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,23 @@
-<p>Hello <%= @resource.email %>!</p>
+<div style="font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif; color: #333333; max-width: 600px; margin: 0 auto; padding: 24px; background-color: #fdfdfd; border: 1px solid #eef0f2; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.02);">
+  
+  <h2 style="font-size: 18px; font-weight: 600; line-height: 1.5; color: #004A77; margin-bottom: 20px; border-bottom: 1px solid #edf2f7; padding-bottom: 12px;">
+    パスワードの再設定手続き
+  </h2>
+  
+  <div style="font-size: 14px; line-height: 1.7; color: #4a5568; margin-bottom: 32px;">
+    <p>こんにちは、<%= @resource.email %> さん</p>
+    <p>いつもご利用いただき、ありがとうございます。</p>
+    <p>パスワードの再設定リクエストを受け付けました。<br />お手数ですが、以下のボタンをクリックして、新しいパスワードのご登録をお願いいたします。</p>
+  </div>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+  <div style="text-align: center; margin-bottom: 32px;">
+    <%= link_to 'パスワードを再設定する', edit_password_url(@resource, reset_password_token: @token), 
+        style: "display: inline-block; padding: 14px 36px; font-size: 15px; font-weight: bold; color: #004A77; background-color: #BDE3F4; text-decoration: none; border-radius: 9999px; box-shadow: 0 2px 4px rgba(0,0,0,0.02);" %>
+  </div>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+  <div style="border-top: 1px solid #edf2f7; padding-top: 20px; font-size: 12px; color: #a0aec0; text-align: left; line-height: 1.6;">
+    <p>※このメールに心当たりがない場合は、他の方がメールアドレスを誤って入力した可能性があります。あなたが上記のリンクにアクセスして新しいパスワードを設定しない限り、パスワードが変更されることはありませんのでご安心ください。</p>
+    <p>※このメールは送信専用アドレスから配信されています。ご返信いただけませんのでご了承ください。</p>
+    <p style="margin-top: 16px; font-weight: 500; text-align: center;">&copy; FanPocket</p>
+  </div>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -14,7 +14,7 @@
     </header>
 
     <!-- Central Form Card -->
-    <main class="w-full relative bg-white/80 backdrop-blur-sm p-8 rounded-[2rem] shadow-[0_8px_32px_rgba(49,51,50,0.06)] border border-surface-container/30">
+    <main class="w-full relative space-y-8">
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-8" }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
         <%= f.hidden_field :reset_password_token %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,79 @@
-<h2>Change your password</h2>
+<div class="relative flex flex-col items-center justify-start min-h-screen pt-16 pb-32 px-6 md:px-8 bg-transparent">
+  <!-- Container -->
+  <div class="relative z-10 w-full max-w-[420px] flex flex-col space-y-10">
+    
+    <!-- Header Section -->
+     <header class="text-center">
+      <div class="inline-flex items-center justify-center w-16 h-16 bg-[#e0f2fe]/30 rounded-3xl mb-4">
+        <span class="material-symbols-outlined text-primary text-3xl">lock_reset</span>
+      </div>
+      <h1 class="text-2xl font-bold text-primary mb-2 tracking-tight">パスワードの再設定</h1>
+      <p class="text-sm font-medium text-gray-500 leading-relaxed px-4">
+        新しく設定するパスワードを入力してください。
+      </p>
+    </header>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <!-- Central Form Card -->
+    <main class="w-full relative bg-white/80 backdrop-blur-sm p-8 rounded-[2rem] shadow-[0_8px_32px_rgba(49,51,50,0.06)] border border-surface-container/30">
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-8" }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
+        <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <p><%= f.label :password, "New password" %></p>
-    <% if @minimum_password_length %>
-      <p><em>(<%= @minimum_password_length %> characters minimum)</em></p>
-    <% end %>
-    <p><%= f.password_field :password, autofocus: true, autocomplete: "new-password" %></p>
+        <div class="space-y-6">
+          <!-- New Password Input -->
+          <div class="flex flex-col space-y-3">
+            <%= f.label :password, "新しいパスワード", class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
+            
+            <div class="relative group" data-controller="password-toggle">
+              <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
+                <span class="material-symbols-outlined text-[20px]">lock</span>
+              </div>
+              
+              <%= f.password_field :password, autofocus: true, autocomplete: "new-password", placeholder: "••••••••", 
+                  class: "w-full h-14 pl-14 pr-14 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
+                  data: { password_toggle_target: "input" } %>
+              
+              <button type="button" 
+                      class="absolute inset-y-0 right-0 pr-6 flex items-center text-[#8BBEE8] hover:text-primary transition-colors duration-200 focus:outline-none"
+                      data-action="click->password-toggle#toggle"
+                      data-password-toggle-target="icon">
+              </button>
+            </div>
+            <% if @minimum_password_length %>
+              <p class="px-6 text-[10px] text-gray-400 font-medium tracking-wide">* <%= @minimum_password_length %> 文字以上入力してください</p>
+            <% end %>
+          </div>
+
+          <!-- Password Confirmation Input -->
+          <div class="flex flex-col space-y-3">
+            <%= f.label :password_confirmation, "新しいパスワード（確認）", class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
+            
+            <div class="relative group" data-controller="password-toggle">
+              <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
+                <span class="material-symbols-outlined text-[20px]">verified_user</span>
+              </div>
+              
+              <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", 
+                  class: "w-full h-14 pl-14 pr-14 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
+                  data: { password_toggle_target: "input" } %>
+              
+              <button type="button" 
+                      class="absolute inset-y-0 right-0 pr-6 flex items-center text-[#8BBEE8] hover:text-primary transition-colors duration-200 focus:outline-none"
+                      data-action="click->password-toggle#toggle"
+                      data-password-toggle-target="icon">
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Submit Button -->
+        <div class="pt-2">
+          <%= f.button class: "w-full h-16 bg-[#BDE3F4] text-[#004A77] font-bold rounded-full active:scale-[0.98] hover:brightness-105 transition-all flex items-center justify-center space-x-3 text-xl shadow-sm" do %>
+            <span class="material-symbols-outlined text-2xl">lock_reset</span>
+            <span>変更する</span>
+          <% end %>
+        </div>
+      <% end %>
+    </main>
   </div>
-
-  <div class="field">
-    <p><%= f.label :password_confirmation, "Confirm new password" %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -11,7 +11,7 @@
       </p>
     </header>
 
-    <main class="w-full relative bg-white/80 backdrop-blur-sm p-8 rounded-[2rem] shadow-[0_8px_32px_rgba(49,51,50,0.06)] border border-surface-container/30">
+    <main class="w-full relative space-y-8">
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-8" }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,48 @@
-<h2>Forgot your password?</h2>
+<div class="relative flex flex-col items-center justify-start min-h-screen pt-16 pb-32 px-6 md:px-8 bg-transparent">
+  <div class="relative z-10 w-full max-w-[420px] flex flex-col space-y-10">
+    
+    <header class="text-center">
+      <div class="inline-flex items-center justify-center w-16 h-16 bg-[#e0f2fe]/30 rounded-3xl mb-4">
+        <span class="material-symbols-outlined text-primary text-3xl">lock_reset</span>
+      </div>
+      <h1 class="text-2xl font-bold text-primary mb-2 tracking-tight">パスワードの再設定</h1>
+      <p class="text-sm font-medium text-gray-500 leading-relaxed px-4">
+        ご登録済みのメールアドレスを入力してください。<br/>パスワード再設定用のリンクをお送りします。
+      </p>
+    </header>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <main class="w-full relative bg-white/80 backdrop-blur-sm p-8 rounded-[2rem] shadow-[0_8px_32px_rgba(49,51,50,0.06)] border border-surface-container/30">
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-8" }) do |f| %>
+        <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+        <div class="space-y-6">
+          <div class="flex flex-col space-y-3">
+            <%= f.label :email, "メールアドレス", class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
+            <div class="relative group">
+              <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
+                <span class="material-symbols-outlined text-[20px]">mail</span>
+              </div>
+              <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "example@mail.com", 
+                  class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="pt-2">
+          <%= f.button class: "w-full h-16 bg-[#BDE3F4] text-[#004A77] font-bold rounded-full active:scale-[0.98] hover:brightness-105 transition-all flex items-center justify-center space-x-3 text-xl shadow-sm" do %>
+            <span class="material-symbols-outlined text-2xl">send</span>
+            <span>送信する</span>
+          <% end %>
+        </div>
+      <% end %>
+    </main>
+
+    <footer class="flex flex-col items-center space-y-4 pt-4">
+      <p class="text-xs text-gray-400 font-medium italic opacity-80 text-center">
+        ※メールが届かない場合は、迷惑メールフォルダをご確認ください。
+      </p>
+      <%= link_to "ログインはこちら", new_session_path(resource_name), class: "text-primary font-bold text-sm hover:underline decoration-2 underline-offset-4" %>
+    </footer>
+
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me password reset instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -31,27 +31,48 @@
           </div>
 
           <div class="flex flex-col space-y-3">
-            <%= f.label :password, "パスワード", class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
-            <div class="relative group">
-              <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
-                <span class="material-symbols-outlined text-[20px]">lock</span>
-              </div>
-              <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", 
-                  class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300" %>
-            </div>
-            <% if @minimum_password_length %>
-              <p class="px-6 text-[10px] text-gray-400 font-medium tracking-wide">* <%= @minimum_password_length %> 文字以上入力してください</p>
-            <% end %>
-          </div>
 
-          <div class="flex flex-col space-y-3">
-            <%= f.label :password_confirmation, "パスワード（確認）", class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
-            <div class="relative group">
-              <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
-                <span class="material-symbols-outlined text-[20px]">verified_user</span>
-              </div>
-              <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", 
-                class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300" %>
+          <%= f.label :password, "パスワード", class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
+  
+          <div class="relative group" data-controller="password-toggle">
+            <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
+              <span class="material-symbols-outlined text-[20px]">lock</span>
+            </div>
+    
+            <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", 
+                class: "w-full h-14 pl-14 pr-14 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
+                data: { password_toggle_target: "input" } %>
+
+            <%# 切り替えボタンを配置 %>
+            <button type="button" 
+                    class="absolute inset-y-0 right-0 pr-6 flex items-center text-[#8BBEE8] hover:text-primary transition-colors duration-200 focus:outline-none"
+                    data-action="click->password-toggle#toggle"
+                    data-password-toggle-target="icon">
+            </button>
+          </div>
+          <% if @minimum_password_length %>
+            <p class="px-6 text-[10px] text-gray-400 font-medium tracking-wide">* <%= @minimum_password_length %> 文字以上入力してください</p>
+          <% end %>
+        </div>
+
+        <div class="flex flex-col space-y-3">
+          <%= f.label :password_confirmation, "パスワード（確認）", class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
+  
+          <div class="relative group" data-controller="password-toggle">
+            <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
+              <span class="material-symbols-outlined text-[20px]">verified_user</span>
+            </div>
+    
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "••••••••", 
+              class: "w-full h-14 pl-14 pr-14 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
+              data: { password_toggle_target: "input" } %>
+
+            <%# 切り替えボタンを配置 %>
+            <button type="button" 
+                    class="absolute inset-y-0 right-0 pr-6 flex items-center text-[#8BBEE8] hover:text-primary transition-colors duration-200 focus:outline-none"
+                    data-action="click->password-toggle#toggle"
+                    data-password-toggle-target="icon">
+            </button>
           </div>
         </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -44,12 +44,25 @@
           <!-- Password Input -->
           <div class="flex flex-col space-y-3">
             <%= f.label :password, "パスワード", class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
-            <div class="relative group">
+            
+            <%# Stimulusコントローラーの指定（相対配置 relative） %>
+            <div class="relative group" data-controller="password-toggle">
               <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
                 <span class="material-symbols-outlined text-[20px]">lock</span>
               </div>
-              <%= f.password_field :password, autocomplete: "new-password", placeholder: "••••••••", 
-                  class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300" %>
+              
+              <%# pr-8 から pr-14 に変更し、文字が右端のアイコンと被らないように調整 %>
+              <%= f.password_field :password, autocomplete: "current-password", placeholder: "••••••••", 
+                  class: "w-full h-14 pl-14 pr-14 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
+                  data: { password_toggle_target: "input" } %>
+              
+              <%# 切り替えボタン（右端に絶対配置） %>
+              <button type="button" 
+                      class="absolute inset-y-0 right-0 pr-6 flex items-center text-[#8BBEE8] hover:text-primary transition-colors duration-200 focus:outline-none"
+                      data-action="click->password-toggle#toggle"
+                      data-password-toggle-target="icon">
+                <%# StimulusからSVGアイコンが動的に挿入されます %>
+              </button>
             </div>
           </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -93,12 +93,12 @@
     <footer class="flex flex-col items-center space-y-4 pt-4 pb-8">
       <div class="flex flex-col sm:flex-row items-center sm:space-x-2 space-y-1 sm:space-y-0 text-center">
         <span class="text-gray-500 text-sm">アカウントをお持ちでないですか？</span>
-        <%= link_to "新規登録はこちら", new_registration_path(resource_name), class: "text-primary font-bold text-sm hover:underline decoration-2 underline-offset-4" %>
+        <%= link_to "新規登録はこちら", new_registration_path(resource_name), class: "text-primary text-sm font-semibold hover:opacity-70 transition-opacity" %>
       </div>
       <%# classを1つに統合し、横並びや間隔を調整しやすいように調整 %>
       <div class="flex gap-4">
-        <%= link_to '利用規約', terms_path, class: "link link-hover text-primary font-bold text-sm hover:underline decoration-2 underline-offset-4" %>
-        <%= link_to 'プライバシーポリシー', privacy_path, class: "link link-hover text-primary font-bold text-sm hover:underline decoration-2 underline-offset-4" %>
+        <%= link_to '利用規約', terms_path, class: "text-primary text-sm font-semibold hover:opacity-70 transition-opacity" %>
+        <%= link_to 'プライバシーポリシー', privacy_path, class: "text-primary text-sm font-semibold hover:opacity-70 transition-opacity" %>
       </div>
     </footer>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,8 +12,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700;800&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
   </head>
-    <div data-controller="flash" class="fixed z-0 blur-[100px] rounded-full bg-[#e0f2fe] opacity-50 w-[500px] h-[500px] -top-20 -right-20 pointer-events-none"></div>
-  <div class="fixed z-0 blur-[100px] rounded-full bg-[#e0f2fe] opacity-40 w-[400px] h-[400px] -bottom-20 -left-20 pointer-events-none"></div>
+    <div class="fixed z-0 blur-[100px] rounded-full bg-[#e0f2fe] opacity-50 w-[500px] h-[500px] -top-20 -right-20 pointer-events-none"></div>
+    <div class="fixed z-0 blur-[100px] rounded-full bg-[#e0f2fe] opacity-40 w-[400px] h-[400px] -bottom-20 -left-20 pointer-events-none"></div>
   <body>
     <% if notice %>
       <div data-controller="flash" data-action="click->flash#dismiss" class="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-xs cursor-pointer select-none">

--- a/app/views/notification_mailer/day_before_notice.html.erb
+++ b/app/views/notification_mailer/day_before_notice.html.erb
@@ -12,7 +12,7 @@
 
   <!-- アクションボタン（手続きページへの導線） -->
   <div style="text-align: center; margin-bottom: 32px;">
-    <a href="<%= root_url %>" style="display: inline-block; padding: 12px 36px; font-size: 15px; font-weight: 500; color: #ffffff; background-color: #66B2FF; text-decoration: none; border-radius: 6px; transition: background-color 0.2s;">
+    <a href="<%= root_url %>" style="display: inline-block; padding: 14px 36px; font-size: 15px; font-weight: bold; color: #ffffff; background-color: #66B2FF; text-decoration: none; border-radius: 9999px; box-shadow: 0 2px 4px rgba(0,0,0,0.02);">
       詳細を確認する
     </a>
   </div>

--- a/app/views/notification_mailer/send_notice.html.erb
+++ b/app/views/notification_mailer/send_notice.html.erb
@@ -12,7 +12,7 @@
 
   <!-- アクションボタン（手続きページへの導線） -->
   <div style="text-align: center; margin-bottom: 32px;">
-    <a href="<%= root_url %>" style="display: inline-block; padding: 12px 36px; font-size: 15px; font-weight: 500; color: #ffffff; background-color: #66B2FF; text-decoration: none; border-radius: 6px; transition: background-color 0.2s;">
+    <a href="<%= root_url %>" style="display: inline-block; padding: 14px 36px; font-size: 15px; font-weight: bold; color: #ffffff; background-color: #66B2FF; text-decoration: none; border-radius: 9999px; box-shadow: 0 2px 4px rgba(0,0,0,0.02);">
       詳細を確認する
     </a>
   </div>

--- a/app/views/notification_mailer/start_notice.html.erb
+++ b/app/views/notification_mailer/start_notice.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div style="text-align: center; margin-bottom: 32px;">
-    <a href="<%= root_url %>" style="display: inline-block; padding: 12px 36px; font-size: 15px; font-weight: 500; color: #ffffff; background-color: #FF66A3; text-decoration: none; border-radius: 6px; transition: background-color 0.2s;">
+    <a href="<%= root_url %>" style="display: inline-block; padding: 14px 36px; font-size: 15px; font-weight: bold; color: #ffffff; background-color: #FF66A3; text-decoration: none; border-radius: 9999px; box-shadow: 0 2px 4px rgba(0,0,0,0.02);">
       詳細を確認する
     </a>
   </div>

--- a/app/views/notification_mailer/three_days_ago_notice.html.erb
+++ b/app/views/notification_mailer/three_days_ago_notice.html.erb
@@ -12,7 +12,7 @@
 
   <!-- アクションボタン（手続きページへの導線） -->
   <div style="text-align: center; margin-bottom: 32px;">
-    <a href="<%= root_url %>" style="display: inline-block; padding: 12px 36px; font-size: 15px; font-weight: 500; color: #ffffff; background-color: #66B2FF; text-decoration: none; border-radius: 6px; transition: background-color 0.2s;">
+    <a href="<%= root_url %>" style="display: inline-block; padding: 14px 36px; font-size: 15px; font-weight: bold; color: #ffffff; background-color: #66B2FF; text-decoration: none; border-radius: 9999px; box-shadow: 0 2px 4px rgba(0,0,0,0.02);">
       詳細を確認する
     </a>
   </div>

--- a/app/views/notification_mailer/today_notice.html.erb
+++ b/app/views/notification_mailer/today_notice.html.erb
@@ -12,7 +12,7 @@
 
   <!-- アクションボタン（手続きページへの導線） -->
   <div style="text-align: center; margin-bottom: 32px;">
-    <a href="<%= root_url %>" style="display: inline-block; padding: 12px 36px; font-size: 15px; font-weight: 500; color: #ffffff; background-color: #FF66A3; text-decoration: none; border-radius: 6px; transition: background-color 0.2s;">
+    <a href="<%= root_url %>" style="display: inline-block; padding: 14px 36px; font-size: 15px; font-weight: bold; color: #ffffff; background-color: #FF66A3; text-decoration: none; border-radius: 9999px; box-shadow: 0 2px 4px rgba(0,0,0,0.02);">
       詳細を確認する
     </a>
   </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -132,7 +132,7 @@ Devise.setup do |config|
   # config.send_email_changed_notification = false
 
   # Send a notification email when the user's password is changed.
-  # config.send_password_change_notification = false
+   config.send_password_change_notification = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without


### PR DESCRIPTION
## 概要
ログイン・新規登録・パスワードリセット画面のUIをFanPocketの世界観に統一し、各種通知メールの文章修正・ボタンデザインの丸角化、およびパスワード入力の表示切り替え（目のアイコン）機能を実装しました。また、パスワード変更完了時の自動メール通知を有効化しました。

## 背景
- 認証まわりの画面や通知メールがデフォルトのままであり、アプリ全体の優しく落ち着いた世界観（FanPocketのトーン＆マナー）と乖離していたため。
- パスワード入力時の利便性（UX）向上のため。
- パスワード変更が成功した際に、ユーザーへ安心感を与えるための完了通知メールがデフォルトでオフになっていたため。

## 変更内容
- **画面全体のUI刷新**: ログイン・新規登録・パスワードリセット画面を Tailwind CSS / daisyUI を用いて、カード型かつフォントやカラーが統一された綺麗なUIに変更しました。
- **ホバーエフェクトの統一**: 各画面のフッターリンク（利用規約、プライバシーポリシー、パスワードを忘れた場合など）の挙動を `hover:opacity-70 transition-opacity` による「ふわっ」とした半透明化に統一しました。
- **通知メールの最適化と自動送信有効化**: 
  - 「前日」「3日前」「当日」「開始」の各リマインドメール、およびDeviseのパスワード変更完了メールの内容を丁寧な日本語に変更し、ボタンをパスワードメールとシンクロする丸角デザイン（`9999px`）に一貫させました。
  - `config/initializers/devise.rb` の `send_password_change_notification` を `true` に設定し、パスワード変更完了メールが実際にユーザーへ自動送信されるよう修正しました。
- **パスワード表示切り替え**: パスワード入力欄と確認用入力欄の双方に「目のアイコン」を配置し、クリックで「●●●」と「実際の文字列」が切り替わるJavaScript（またはStimulus）機能を実装しました。アイコンの形状も状態に連動します。

## 確認方法
1. 各画面（ログイン、新規登録、パスワードリセット）を開き、全体のデザインとフッターリンクのホバー挙動を確認。
2. パスワードリセット画面で、パスワード入力欄の「目のアイコン」をクリックし、文字の表示/非表示およびアイコンが正常に切り替わるか確認。
3. 実際にパスワードリセットを実行し、変更完了時に Letter Opener に新しくデザインした「パスワード変更完了のお知らせ」メールが自動で届くことを確認。

## 影響範囲
- ログイン / 新規登録 / パスワードリセット画面
- 各種通知メール（リマインド、パスワード変更完了）
- Deviseの設定（`config/initializers/devise.rb`）

## スクリーンショット（任意）
スクリーンショット
【パスワードを再設定用のメール入力画面】
<img width="1920" height="988" alt="image" src="https://github.com/user-attachments/assets/c938c3b3-fdf9-4de9-a608-e1fd8aa0d9ed" />

【パスワードリセット画面】
<img width="1920" height="995" alt="image" src="https://github.com/user-attachments/assets/69b1d29a-9c91-4f0a-a8ea-4d2369f5f829" />

【パスワード再設定用メール】
<img width="1479" height="993" alt="image" src="https://github.com/user-attachments/assets/1bfa36dc-ab8d-4df3-9d21-2a2e42fd5846" />

【パスワードリセット完了メール】
<img width="1478" height="987" alt="image" src="https://github.com/user-attachments/assets/c5810078-b4b3-4195-bc17-c6473f3ac748" />

【通知メールのボタンを丸角に変更】
<img width="1481" height="986" alt="image" src="https://github.com/user-attachments/assets/8f1ba72b-a3c2-455b-b14e-6e28bce5fc60" />

<img width="1481" height="992" alt="image" src="https://github.com/user-attachments/assets/ea56fb50-8452-43e2-8c1f-87731c2984c0" />


## 補足
Docker環境において、メールテンプレート（`.html.erb`）の変更が即時反映されない事象がありましたが、コンテナを再起動することで無事にキャッシュがクリアされ、意図通りの丸角デザインが表示されることを確認済みです。みです。