### PR TITLE
Fix: 本番環境でのメール送信エラー解消およびロゴ画像のインライン埋め込み対応

### DIFF
--- a/app/mailers/welcome_mailer.rb
+++ b/app/mailers/welcome_mailer.rb
@@ -3,6 +3,8 @@ class WelcomeMailer < ApplicationMailer
 
   def send_welcome_email(user)
     @user = user
+    # メールの添付データとしてロゴ画像を登録（インライン配置用）
+    attachments.inline['logo.png'] = File.read(Rails.root.join('app/assets/images/logo.png'))
 
     mail(
       to: @user.email,

--- a/app/views/welcome_mailer/send_welcome_email.html.erb
+++ b/app/views/welcome_mailer/send_welcome_email.html.erb
@@ -18,7 +18,7 @@
       <table align="center" border="0" cellpadding="0" cellspacing="0" style="background-color: #ffffff; border: 1px solid #edf2f7; border-radius: 9999px; box-shadow: 0 2px 4px rgba(0,0,0,0.02); margin: 0 auto;">
         <tr>
           <td style="padding: 10px 24px; text-align: center; vertical-align: middle;">
-            <%= image_tag asset_url('logo.png'), style: "width: 24px; height: 24px; margin-right: 8px; vertical-align: middle; display: inline-block; object-fit: contain;", alt: "FanPocket Logo" %>
+            <%= image_tag attachments['logo.png'].url, style: "width:24px; height:24px; margin-right:8px; vertical-align:middle; display:inline-block; object-fit:contain;", alt: "FanPocket Logo" %>
             <span style="font-family: 'Helvetica Neue', Arial, sans-serif; font-size: 15px; font-weight: bold; color: #004A77; vertical-align: middle; display: inline-block; line-height: 24px;">
               FanPocket にログインする
             </span>


### PR DESCRIPTION
## 概要
本番環境（Render）において、新規登録時に発生していたエラーの解消、Sidekiqによる非同期メール送信の有効化、および受信メール内でのロゴ画像の表示切れ（?マーク）の修正を行いました。

## 変更内容
### 1. アプリケーションコード側（本ブランチでの修正内容）
* **メール内ロゴ画像のインライン埋め込み対応**
  * `UserMailer` にて、ロゴ画像を `attachments.inline` を用いてメールデータに直接添付するよう修正。
  * メールのビュー（HTML）側で、通常の `image_tag` から `attachments['logo.png'].url` を参照する形に変更し、Gmail等のメールクライアントで画像がブロックされないように対応しました。

### 2. インフラ・環境設定側（Render / Upstashでの対応内容）
* **Upstash Redis の再作成と接続修正**
  * 削除されていたRedisを再作成し、Renderの環境変数 `REDIS_URL` を正しいURI形式に修正。
  * 暗号化通信（TLS/SSL）を有効化するため、プロトコルを `redis://` から `rediss://` に変更しました。
* **RenderでのSidekiqマルチプロセス起動設定**
  * 無料プランの制限内でSidekiqを稼働させるため、Renderの `Start Command` を以下のように変更し、1つのWebサービス内でPuma（Rails）とSidekiqが同時に動くように設定しました。
  * `bundle exec sidekiq -C config/sidekiq.yml & bundle exec puma -C config/puma.rb`

## 確認方法
1. 本番環境（Render）にて新規登録を実行。
2. 500エラーが発生せず、正常に登録完了画面へ遷移することを確認。
3. 送信されたウェルカムメールを受信し、ヘッダー等のロゴ画像（FanPocket Logo）が「?」にならず、正常に表示されていることを確認。

## 影響範囲
* ユーザー新規登録フロー
* メール送信処理全般