### PR TITLE
タイトル自動取得機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'letter_opener_web', '~> 3.0'
 
 gem 'sidekiq'
 
+gem 'metainspector'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,11 +117,35 @@ GEM
       railties (>= 7.0)
       responders
       warden (~> 1.2.3)
+    domain_name (0.6.20240107)
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-cookie_jar (0.0.8)
+      faraday (>= 0.8.0)
+      http-cookie (>= 1.0.0)
+    faraday-encoding (0.0.6)
+      faraday
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-gzip (3.1.0)
+      faraday (>= 2.0, < 3)
+      zlib (~> 3.0)
+    faraday-http-cache (2.7.0)
+      faraday (>= 0.8)
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
+    fastimage (2.4.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    http-cookie (1.1.6)
+      domain_name (~> 0.5)
     httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
@@ -167,6 +191,18 @@ GEM
       net-smtp
     marcel (1.1.0)
     matrix (0.4.3)
+    metainspector (5.17.2)
+      addressable (~> 2.9.0)
+      faraday (~> 2.5)
+      faraday-cookie_jar (~> 0.0)
+      faraday-encoding (~> 0.0)
+      faraday-follow_redirects (~> 0.3)
+      faraday-gzip (>= 0.1, < 4.0)
+      faraday-http-cache (~> 2.5)
+      faraday-retry (~> 2.0)
+      fastimage (~> 2.2)
+      nesty (~> 1.0)
+      nokogiri (~> 1.19.0)
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -175,6 +211,9 @@ GEM
     multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     mutex_m (0.3.0)
+    nesty (1.0.2)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.4)
       date
       net-protocol
@@ -329,6 +368,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    uri (1.1.1)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -344,6 +384,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.7.5)
+    zlib (3.2.3)
 
 PLATFORMS
   x86_64-linux
@@ -357,6 +398,7 @@ DEPENDENCIES
   jbuilder
   letter_opener
   letter_opener_web (~> 3.0)
+  metainspector
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.6)
@@ -378,4 +420,4 @@ RUBY VERSION
   ruby 3.2.2
 
 BUNDLED WITH
-  4.0.11
+  4.0.15

--- a/app/controllers/url_parsers_controller.rb
+++ b/app/controllers/url_parsers_controller.rb
@@ -1,0 +1,25 @@
+class UrlParsersController < ApplicationController
+  def fetch_title
+    url = params[:url]
+
+    if url.blank?
+      return render json: { error: 'URLが入力されていません' }, status: :bad_request
+    end
+
+    begin
+      # タイムアウトを5秒に設定して安全に解析
+      page = MetaInspector.new(url, connection_timeout: 5, read_timeout: 5, retries: 1)
+      title = page.best_title
+
+      if title.present?
+        render json: { title: title }
+      else
+        render json: { error: 'タイトルが取得できませんでした' }, status: :unprocessable_entity
+      end
+
+    rescue MetaInspector::Error, StandardError => e
+      logger.error "URL解析エラー: #{e.message}"
+      render json: { error: 'タイトルが取得できませんでした' }, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -2,7 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = [ 
-    "titleInput", "titleErrorMessage", 
+    "titleInput", "titleErrorMessage",
+    "urlInput", "fetchButton", "noticeMessage", 
     "startAtInput", "startErrorMessage", 
     "endAtInput", "errorMessage" 
   ]
@@ -67,6 +68,58 @@ export default class extends Controller {
     }
   }
 
+  // タイトルを自動取得するメイン処理
+  async fetchTitle() {
+    const url = this.urlInputTarget.value.trim()
+
+    if (!url) {
+      this.showNotice("URLを入力してください", "text-error")
+      return
+    }
+
+    this.setLoading(true)
+
+    try {
+      const response = await fetch(`/url_parsers/fetch_title?url=${encodeURIComponent(url)}`)
+      const data = await response.json()
+
+      if (response.ok && data.title) {
+        this.titleInputTarget.value = data.title
+        this.showNotice("タイトルを取得しました！", "text-success text-primary")
+        
+        if (typeof this.checkTitle === "function") {
+          this.checkTitle()
+        }
+      } else {
+        this.showNotice(data.error || "タイトルが取得できませんでした", "text-neutral-500 font-normal")
+      }
+    } catch (error) {
+      console.error(error)
+      this.showNotice("タイトルが取得できませんでした", "text-neutral-500 font-normal")
+    } finally {
+      this.setLoading(false)
+    }
+  }
+
+  // 状態通知メッセージを表示するヘルパーメソッド
+  showNotice(message, colorClass) {
+    this.noticeMessageTarget.textContent = message
+    this.noticeMessageTarget.className = `text-xs font-semibold pl-4 flex items-center gap-1 ${colorClass}`
+  }
+
+  // ボタンのローディング状態を切り替えるヘルパーメソッド
+  setLoading(isLoading) {
+    if (isLoading) {
+      this.fetchButtonTarget.disabled = true
+      this.fetchButtonTarget.classList.add("opacity-60", "cursor-not-allowed")
+      this.fetchButtonTarget.querySelector("[data-watchlist-form-target='buttonText']").textContent = "取得中..."
+    } else {
+      this.fetchButtonTarget.disabled = false
+      this.fetchButtonTarget.classList.remove("opacity-60", "cursor-not-allowed")
+      this.fetchButtonTarget.querySelector("[data-watchlist-form-target='buttonText']").textContent = "タイトルを自動取得する"
+    }
+  }
+
   // 開始日時のチェック
   checkStartDate() {
     if (!this.hasStartAtInputTarget || !this.hasStartErrorMessageTarget) return
@@ -100,4 +153,4 @@ export default class extends Controller {
       this.errorMessageTarget.classList.remove("hidden")
     }
   }
-}
+} 

--- a/app/views/watchlists/_form.html.erb
+++ b/app/views/watchlists/_form.html.erb
@@ -1,5 +1,6 @@
-<%= form_with model: watchlist, class: "space-y-10", html: { novalidate: true }, local: true do |f| %>
-  <!-- エラーメッセージ表示 -->
+<%= form_with model: watchlist, class: "space-y-10", html: { novalidate: true }, local: true, 
+    data: { controller: "watchlist-form" } do |f| %>
+  
   <% if watchlist.errors[:base].any? %>
     <div class="bg-error/10 border border-error/20 text-error p-4 rounded-2xl text-sm font-medium">
       <div class="flex items-center gap-2">
@@ -9,85 +10,81 @@
     </div>
   <% end %>
 
-  <!-- URL Input Section -->
   <div class="space-y-3">
     <%= f.label :url, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
       <span class="material-symbols-outlined text-lg">link</span>URL
     <% end %>
-    <%# エラーがある場合は ring-error を付与 %>
-    <%= f.url_field :url, class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:url].any?}", placeholder: "https://example.com/event-page" %>
-    <%# 個別エラーメッセージ %>
-   <% if watchlist.errors[:url].any? %>
+    
+    <%= f.url_field :url, 
+        data: { watchlist_form_target: "urlInput" },
+        class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:url].any?}", placeholder: "https://example.com/event-page" %>
+    
+    <% if watchlist.errors[:url].any? %>
       <p class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
         <span class="material-symbols-outlined text-sm">info</span>
         <%= watchlist.errors.full_messages_for(:url).first %>
       </p>
     <% end %>
 
-    <button class="text-primary bg-[#B6E0F3]/50 font-bold text-xs flex items-center gap-1.5 hover:opacity-80 transition-opacity ml-1 bg-accent-soft/40 px-3 py-2 rounded-full active:scale-95" type="button">
-      <span class="material-symbols-outlined text-sm">auto_fix</span>タイトルを自動取得する
+    <button class="text-primary bg-[#B6E0F3]/50 font-bold text-xs flex items-center gap-1.5 hover:opacity-80 transition-opacity ml-1 bg-accent-soft/40 px-3 py-2 rounded-full active:scale-95" 
+            type="button"
+            data-action="click->watchlist-form#fetchTitle"
+            data-watchlist-form-target="fetchButton">
+      <span class="material-symbols-outlined text-sm">auto_fix</span>
+      <span data-watchlist-form-target="buttonText">タイトルを自動取得する</span>
     </button>
+    
+    <p data-watchlist-form-target="noticeMessage" class="text-xs font-semibold pl-4 hidden flex items-center gap-1"></p>
   </div>
 
-  <!-- Title Input Section -->
-  <div data-controller="watchlist-form">
+  <div class="space-y-3">
+    <%= f.label :title, "タイトル", class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" %>
+    
+    <%= f.text_field :title, 
+          data: { 
+            watchlist_form_target: "titleInput",
+            action: "input->watchlist-form#checkTitle"
+          }, 
+          class: "w-full h-14 px-6 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:title].any?}", placeholder: "タイトルを入力" %>
 
-  <%= form_with(model: watchlist) do |f| %>
+    <% if watchlist.errors[:title].any? %>
+      <p data-watchlist-form-target="titleErrorMessage" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
+        <span class="material-symbols-outlined text-sm">info</span>
+        <%= watchlist.errors.full_messages_for(:title).first %>
+      </p>
+    <% end %>
+  </div>
 
+  <div class="grid grid-cols-1 gap-8 mt-8">
     <div class="space-y-3">
-      <%= f.label :title, "タイトル", class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" %>
-      
-      <%= f.text_field :title, 
-            data: { 
-              watchlist_form_target: "titleInput",
-              action: "input->watchlist-form#checkTitle"
-            }, 
-            class: "w-full h-14 px-6 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:title].any?}", placeholder: "タイトルを入力" %>
+      <%= f.label :start_at, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
+        <span class="material-symbols-outlined text-lg">calendar_today</span>開始日時
+      <% end %>
+      <%= f.text_field :start_at, data: { controller: "flatpickr", watchlist_form_target: "startAtInput" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:start_at].any?}", placeholder: "年/月/日 --:--" %>
 
-      <% if watchlist.errors[:title].any? %>
-        <p data-watchlist-form-target="titleErrorMessage" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
+      <% if watchlist.errors[:start_at].any? %>
+        <p data-watchlist-form-target="startErrorMessage" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
           <span class="material-symbols-outlined text-sm">info</span>
-          <%= watchlist.errors.full_messages_for(:title).first %>
+          <%= watchlist.errors.full_messages_for(:start_at).first %>
         </p>
       <% end %>
     </div>
 
-
-    <div class="grid grid-cols-1 gap-8 mt-8">
+    <div class="space-y-3">
+      <%= f.label :end_at, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
+        <span class="material-symbols-outlined text-lg">timer</span>締切日時
+      <% end %>
+      <%= f.text_field :end_at, data: { controller: "flatpickr", watchlist_form_target: "endAtInput" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:end_at].any?}", placeholder: "年/月/日 --:--" %>
       
-      <div class="space-y-3">
-        <%= f.label :start_at, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
-          <span class="material-symbols-outlined text-lg">calendar_today</span>開始日時
-        <% end %>
-        <%= f.text_field :start_at, data: { controller: "flatpickr", watchlist_form_target: "startAtInput" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:start_at].any?}", placeholder: "年/月/日 --:--" %>
-
-        <% if watchlist.errors[:start_at].any? %>
-          <p data-watchlist-form-target="startErrorMessage" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
-            <span class="material-symbols-outlined text-sm">info</span>
-            <%= watchlist.errors.full_messages_for(:start_at).first %>
-          </p>
-        <% end %>
-      </div>
-
-      <div class="space-y-3">
-        <%= f.label :end_at,  class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
-          <span class="material-symbols-outlined text-lg">timer</span>締切日時
-        <% end %>
-        <%= f.text_field :end_at, data: { controller: "flatpickr", watchlist_form_target: "endAtInput" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:end_at].any?}", placeholder: "年/月/日 --:--" %>
-        
-        <% if watchlist.errors[:end_at].any? %>
-          <p data-watchlist-form-target="errorMessage" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
-            <span class="material-symbols-outlined text-sm">info</span>
-            <%= watchlist.errors.full_messages_for(:end_at).first %>
-          </p>
-        <% end %>
-      </div>
-
+      <% if watchlist.errors[:end_at].any? %>
+        <p data-watchlist-form-target="errorMessage" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
+          <span class="material-symbols-outlined text-sm">info</span>
+          <%= watchlist.errors.full_messages_for(:end_at).first %>
+        </p>
+      <% end %>
     </div>
+  </div>
 
-    <% end %>
-
-  <!-- Memo Section -->
   <div class="space-y-3">
     <%= f.label :memo, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
       <span class="material-symbols-outlined text-lg">description</span>メモ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,10 @@ Rails.application.routes.draw do
 
   resources :watchlists, only: [:index, :show, :new, :create, :edit, :update, :destroy]
   resource :settings, only: [:show]
+  
+  resources :url_parsers, only: [] do
+  collection do
+    get :fetch_title
+  end
+end
 end


### PR DESCRIPTION
## 概要
予定追加・編集画面において、URLが入力された際にWebページのタイトルを非同期で自動取得・入力する補助機能を実装しました。

## 背景
ユーザーがイベントやファンクラブのリンクを登録する際、タイトルを手入力する手間を軽減し、よりスムーズに予定を管理できるようにするため。（Issue #ここに対応するIssue番号があれば書く）

## 変更内容
- **バックエンド (Rails)**
  - `MetaInspector` ジェムを導入し、指定されたURLからタイトルを取得する `UrlParsersController#fetch_title` エンドポイントを作成。
  - 相手方サーバーのダウンや無効なURLによる通信エラー時も500エラーにせず、適切なJSONエラーを返す例外処理を実装。
- **フロントエンド (Stimulus / Tailwind CSS / daisyUI)**
  - 既存の `watchlist_form_controller.js` を拡張し、Fetch APIを用いた非同期通信処理（`fetchTitle`）を追加。
  - 通信中の連打を防止するボタンのローディング状態（「取得中...」）の制御を実装。
  - エラー時には真っ赤な警告ではなく、淡いグレーで「タイトルが取得できませんでした」と表示する穏やかなUXに調整。
  - 自動取得成功時、既存のリアルタイムバリデーション（タイトル未入力エラーの非表示化）と綺麗に連動するよう調整。

## 確認方法
1. ログイン後、予定の新規登録（または編集）画面を開く。
2. **正常系（タイトル取得）**: URL欄に `https://yahoo.co.jp` を入力し「タイトルを自動取得する」ボタンを押すと、タイトル欄に「Yahoo! JAPAN」が自動挿入される。タイトル未入力で登録しエラーが出たあとタイトルを自動取得し自動挿入されると未入力エラーが消えること。
3. **異常系（サーバーダウン等）**: URL欄に存在しないドメイン（例: `https://this-is-a-fake-domain-123456789.com`）を入力してボタンを押すと、500エラーにならず「タイトルが取得できませんでした」と優しい通知が出ること。
4. **異常系（無効な形式）**: URL欄に `just_string_not_url` などの不正な文字列を入力し登録しようとすると、URL形式のエラー（赤文字）が表示されること。

## 影響範囲
- 予定（ウォッチリスト）の登録・編集画面
- 既存のリアルタイムバリデーション機能やFlatpickrの動作に影響がないことを確認済み。

## スクリーンショット
**正常系（タイトル取得）**
<img width="1146" height="499" alt="image" src="https://github.com/user-attachments/assets/785c43e4-0628-4558-bdab-b137e5aeb9b3" />
【未入力エラー後自動取得した場合】
<img width="1014" height="411" alt="image" src="https://github.com/user-attachments/assets/fb8bcdeb-00d1-4db6-8210-43b381fe6d84" />

 **異常系（サーバーダウン等）**
<img width="1169" height="441" alt="image" src="https://github.com/user-attachments/assets/0e3a03be-2205-4ad2-9cb2-2e2ed3596b4c" />

 **異常系（無効な形式）**
<img width="1253" height="584" alt="image" src="https://github.com/user-attachments/assets/42bfbccb-d4fd-4127-acb8-14369b324679" />

## 補足
- **設計思想について**
  一部のモダンなJavaScript（SPA）で構築されたサイトでは、MetaInspectorの仕様上、詳細な記事タイトルではなく「サイト名（例：超特急）」のみが取得される挙動になります。
  どうしても詳細なタイトルを取得するためにPlaywright等の自動ブラウザ（ヘッドレスブラウザ）を導入することも検討しましたが、サービス側の利用規約（スクレイピング制限）への配慮、サーバー負荷、および本アプリの「穏やかな世界観」を考慮し、今回は**「ユーザーの入力を手助けする安全な補助的要素」**としてMetaInspectorによる実装に留める着地としました。登録するユーザー自身が内容を認知しているため、これで十分なアシストになると考えています。