### PR TITLE
chore: 暫定対応としてSidekiqの通信頻度とスレッド数を抑制

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,10 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV.fetch('REDIS_URL') }
+  
+  # 予定ジョブ（Scheduled Job）のチェック間隔を5分に広げ、通信回数を激減させる
+  config.options[:scheduled_poll_interval] = 300
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV.fetch('REDIS_URL') }
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: 5
+:concurrency: 1
 :queues:
   - default
   - mailers


### PR DESCRIPTION
## 概要
Upstash Redisの1日あたりのリクエスト制限（50万回）に達してデータベースがロックされる問題を防ぐため、Sidekiqの通信頻度とスレッド数を極限まで抑制する暫定設定を導入しました。

## 背景
GASによる生存監視で本番環境（Render）が起動している時間帯に、Sidekiqのデフォルト設定（concurrency: 5、短時間ポーリング）が原因で大量のRedisコマンドが消費され、Upstashの制限に達してアプリがパケ死状態（エラー無限リトライ）になる事象が発生したため、次の通知最適化アップデート（GAS一本化タスク）までの延命措置として設定変更が必要でした。
（関連Issue: # [ここに暫定対応のIssue番号] ）

## 変更内容
- `config/sidekiq.yml`: `:concurrency`（同時スレッド数）を `5` から `1` に変更し、Upstashへのアクセスプレッシャーを5分の1に削減。
- `config/initializers/sidekiq.rb`: 新規作成し、本番環境での予定ジョブ確認間隔（`:scheduled_poll_interval`）を `300`（5分おき）に設定。定期的なアクセス回数を激減。

## 確認方法
1. 本PRをマージし、Renderへの自動デプロイが正常に完了（`Live` 状態に）することを確認。
2. Renderのアプリログ（Logs）を確認し、以前のように1秒間に何十回もの猛烈な勢いで `ERR max requests limit exceeded` や `heartbeat` のエラーログが連打されていない（数分おき、または停止している）ことを確認。

## 影響範囲
- バックグラウンドジョブ基盤（Sidekiqの設定変更）
- Web側の既存機能やログイン機能（Devise）などの同期的アクセス、およびメールの配信ロジックそのものへの影響はありません。

## スクリーンショット
<img width="1161" height="744" alt="image" src="https://github.com/user-attachments/assets/1a2dcb7d-be2e-43da-a413-cb6a638692a7" />


## 補足
本対応はあくまで将来的なRedis廃止（GAS一本化による通知最適化タスク）までの「暫定の延命措置」です。この設定により、近いうちにUpstash側の制限が自動リセットされれば、再びデータベースが正常稼働し開発を進められるようになります。