### PR TITLE
GitHub Actions実行時のREDIS_URL未設定によるKeyErrorの解消

### DIFF
--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -9,6 +9,13 @@ on:
         required: true
         default: 'morning'
 
+env:
+  RAILS_ENV: production
+  RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+  REDIS_URL: ${{ secrets.REDIS_URL }}
+
 jobs:
   ping_and_notify:
     runs-on: ubuntu-latest
@@ -34,27 +41,15 @@ jobs:
         run: bundle install
 
       # 4. 【朝7時通知】当日・開始日タスクの実行
-      # ※朝のCron（'55 21 * * *'）で起動した時、または手動実行の時に動く
+      # 💡 inputs.notification_type に修正（最新の仕様に準拠）
       - name: Run Same Day Notifications (7:00 JST)
-        if: github.event.inputs.notification_type == 'morning'
-        env: 
-          RAILS_ENV: production
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          REDIS_URL: ${{ secrets.REDIS_URL }}
+        if: inputs.notification_type == 'morning'
         run: bundle exec rake notification:send_same_day
 
       # 5. 【夜20時通知】3日前・前日タスクの実行
-      # ※夜のCron（'55 10 * * *'）で起動した時、または手動実行の時に動く
+      # 💡 inputs.notification_type に修正（最新の仕様に準拠）
       - name: Run Night Notifications (20:00 JST)
-        if: github.event.inputs.notification_type == 'night'
-        env: 
-          RAILS_ENV: production
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
-          REDIS_URL: ${{ secrets.REDIS_URL }}
+        if: inputs.notification_type == 'night'
         run: |
           bundle exec rake notification:send_3days_prior
           bundle exec rake notification:send_day_before

--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -37,24 +37,24 @@ jobs:
       # ※朝のCron（'55 21 * * *'）で起動した時、または手動実行の時に動く
       - name: Run Same Day Notifications (7:00 JST)
         if: github.event.inputs.notification_type == 'morning'
-        run: bundle exec rake notification:send_same_day
-        env:
+        env: 
           RAILS_ENV: production
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           REDIS_URL: ${{ secrets.REDIS_URL }}
+        run: bundle exec rake notification:send_same_day
 
       # 5. 【夜20時通知】3日前・前日タスクの実行
       # ※夜のCron（'55 10 * * *'）で起動した時、または手動実行の時に動く
       - name: Run Night Notifications (20:00 JST)
         if: github.event.inputs.notification_type == 'night'
-        run: |
-          bundle exec rake notification:send_3days_prior
-          bundle exec rake notification:send_day_before
-        env:
+        env: 
           RAILS_ENV: production
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           REDIS_URL: ${{ secrets.REDIS_URL }}
+        run: |
+          bundle exec rake notification:send_3days_prior
+          bundle exec rake notification:send_day_before

--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -43,6 +43,7 @@ jobs:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          REDIS_URL: ${{ secrets.REDIS_URL }}
 
       # 5. 【夜20時通知】3日前・前日タスクの実行
       # ※夜のCron（'55 10 * * *'）で起動した時、または手動実行の時に動く
@@ -56,3 +57,4 @@ jobs:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          REDIS_URL: ${{ secrets.REDIS_URL }}


### PR DESCRIPTION
## 概要
GitHub Actions（CI）実行時に `REDIS_URL` が未設定のため発生していた `KeyError` を、ワークフローファイルの記述修正とGitHub Secretsの設定によって解消しました。

## 背景
本番環境の通知タスク（Rakeタスク）をGitHub Actionsから実行する際、Sidekiqの初期化処理で `REDIS_URL` が取得できず、ビルドが異常終了していました。本番環境の正常な通知運用を維持するため、この暫定復旧対応が必要でした。

closes #111 

## 変更内容
- `.github/workflows/ping-render.yml` 内の `github.event.inputs` を、最新の仕様である `inputs` コンテキストの参照に修正。
- 各ステップ内に散らばっていた `env:` 設定（`REDIS_URL` を含む環境変数）を、ファイル最上部（グローバル）に集約し、すべてのステップに確実に適用されるよう共通化。

## 確認方法
- GitHub Actionsのワークフローがエラー（Exit code 1）にならず、正常にパス（緑）することを確認済み。

## 影響範囲
- GitHub Actionsのワークフロー実行環境のみ。
- ユーザーが触るアプリケーションの画面や機能への直接的な影響はありません。

## スクリーンショット（任意）
<img width="1914" height="975" alt="image" src="https://github.com/user-attachments/assets/28b1b965-1900-4e6b-8415-a89673c63a7b" />

## 補足
当初は各ステップ内に `env:` を追記していましたが、インデントのズレや `inputs` の古い記述仕様による不整合を防ぐため、最上部へのグローバル設定化と最新シンタックスへの書き換えを行いました。
本件で環境変数の土台が整ったため、後日予定している「Redis/Sidekiqの完全廃止およびGAS移行」のIssueへ安全に進むことができます。