### PR TITLE
日付候補の抽出による入力補助機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'letter_opener_web', '~> 3.0'
 gem 'sidekiq'
 
 gem 'metainspector'
+gem "nokogiri"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,6 +399,7 @@ DEPENDENCIES
   letter_opener
   letter_opener_web (~> 3.0)
   metainspector
+  nokogiri
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.6)

--- a/app/controllers/api/date_suggestions_controller.rb
+++ b/app/controllers/api/date_suggestions_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Api
+  class DateSuggestionsController < ApplicationController
+    def index
+      url = params[:url]
+      return render json: { error: 'URLを入力してください' }, status: :bad_request if url.blank?
+
+      target_text = fetch_target_text(url)
+      suggestions = DateExtractorService.new(target_text).call
+
+      render json: { suggestions: suggestions }
+    rescue StandardError => e
+      logger.error "MetaInspector Error: #{e.message}"
+      render json: { suggestions: [], error: 'ページの解析に失敗しました' }, status: :unprocessable_entity
+    end
+
+    private
+
+    def fetch_target_text(url)
+      page = MetaInspector.new(url, connection_options: { request: { timeout: 5 } })
+      "#{page.title} #{page.description} #{page.text}"
+    end
+  end
+end

--- a/app/controllers/api/date_suggestions_controller.rb
+++ b/app/controllers/api/date_suggestions_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-require "open-uri"
+
+require 'net/http'
+require 'uri'
 
 module Api
   class DateSuggestionsController < ApplicationController
@@ -19,13 +21,16 @@ module Api
     private
 
     def fetch_target_text(url)
-      html = URI.open(url).read
-      doc = Nokogiri::HTML(html)
+      uri = URI.parse(url)
 
-      doc.css("script, style").remove
+      response = Net::HTTP.get_response(uri)
+      raise 'ページの取得に失敗しました' unless response.is_a?(Net::HTTPSuccess)
+
+      doc = Nokogiri::HTML(response.body)
+      doc.css('script, style').remove
 
       title = doc.title
-      body = doc.at("body")&.text.to_s.squish
+      body = doc.at('body')&.text.to_s.squish
 
       "#{title} #{body}"
     end

--- a/app/controllers/api/date_suggestions_controller.rb
+++ b/app/controllers/api/date_suggestions_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "open-uri"
 
 module Api
   class DateSuggestionsController < ApplicationController
@@ -11,15 +12,22 @@ module Api
 
       render json: { suggestions: suggestions }
     rescue StandardError => e
-      logger.error "MetaInspector Error: #{e.message}"
+      logger.error "DateSuggestions Error: #{e.message}"
       render json: { suggestions: [], error: 'ページの解析に失敗しました' }, status: :unprocessable_entity
     end
 
     private
 
     def fetch_target_text(url)
-      page = MetaInspector.new(url, connection_options: { request: { timeout: 5 } })
-      "#{page.title} #{page.description} #{page.text}"
+      html = URI.open(url).read
+      doc = Nokogiri::HTML(html)
+
+      doc.css("script, style").remove
+
+      title = doc.title
+      body = doc.at("body")&.text.to_s.squish
+
+      "#{title} #{body}"
     end
   end
 end

--- a/app/controllers/url_parsers_controller.rb
+++ b/app/controllers/url_parsers_controller.rb
@@ -1,25 +1,23 @@
+# frozen_string_literal: true
+
 class UrlParsersController < ApplicationController
   def fetch_title
     url = params[:url]
+    return render json: { error: 'URLが入力されていません' }, status: :bad_request if url.blank?
 
-    if url.blank?
-      return render json: { error: 'URLが入力されていません' }, status: :bad_request
-    end
+    title = extract_title(url)
+    return render json: { title: title } if title.present?
 
-    begin
-      # タイムアウトを5秒に設定して安全に解析
-      page = MetaInspector.new(url, connection_timeout: 5, read_timeout: 5, retries: 1)
-      title = page.best_title
+    render json: { error: 'タイトルが取得できませんでした' }, status: :unprocessable_entity
+  rescue MetaInspector::Error, StandardError => e
+    logger.error "URL解析エラー: #{e.message}"
+    render json: { error: 'タイトルが取得できませんでした' }, status: :unprocessable_entity
+  end
 
-      if title.present?
-        render json: { title: title }
-      else
-        render json: { error: 'タイトルが取得できませんでした' }, status: :unprocessable_entity
-      end
+  private
 
-    rescue MetaInspector::Error, StandardError => e
-      logger.error "URL解析エラー: #{e.message}"
-      render json: { error: 'タイトルが取得できませんでした' }, status: :unprocessable_entity
-    end
+  def extract_title(url)
+    page = MetaInspector.new(url, connection_timeout: 5, read_timeout: 5, retries: 1)
+    page.best_title
   end
 end

--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -150,18 +150,68 @@ export default class extends Controller {
     buttonWrapper.className = "flex flex-wrap gap-2"
 
     suggestions.forEach((suggestion) => {
+    if (suggestion.label.includes("候補")) {
+      const candidateGroup = document.createElement("div")
+      candidateGroup.className = "flex flex-col items-start gap-1"
+
       const button = document.createElement("button")
       button.type = "button"
-      button.textContent = suggestion.label.replace(/^開始: /, "").replace(/^締切: /, "").replace(/^候補: /, "")
+      button.textContent = `${suggestion.label.replace(/^候補: /, "")} ▾`
       button.className = "btn btn-xs btn-outline btn-primary normal-case font-normal"
 
       button.addEventListener("click", () => {
-        if (suggestion.label.includes("候補")) {
-          console.log("候補日が押されました")
-        } else {
-          this.insertDateTime(suggestion.label, suggestion.value)
-        }
+        this.element.querySelectorAll(".date-choice-buttons").forEach(element => element.remove())
+
+        const choiceContainer = document.createElement("div")
+        choiceContainer.className = "date-choice-buttons flex flex-col items-center gap-2 mt-2"
+
+        const message = document.createElement("p")
+        message.textContent = "どちらに入力しますか？"
+        message.className = "text-xs text-gray-500 "
+
+        const startButton = document.createElement("button")
+        startButton.type = "button"
+        startButton.textContent = "開始日時へ"
+        startButton.className = "btn btn-xs btn-outline btn-secondary normal-case font-normal"
+
+        const endButton = document.createElement("button")
+        endButton.type = "button"
+        endButton.textContent = "締切日時へ"
+        endButton.className = "btn btn-xs btn-outline btn-accent normal-case font-normal"
+
+        const buttonRow = document.createElement("div")
+        buttonRow.className = "flex gap-2"
+
+        startButton.addEventListener("click", () => {
+          this.insertDateTime("開始", suggestion.value)
+        })
+
+        endButton.addEventListener("click", () => {
+          this.insertDateTime("締切", suggestion.value)
+        })
+
+        buttonRow.appendChild(startButton)
+        buttonRow.appendChild(endButton)
+
+        choiceContainer.appendChild(message)
+        choiceContainer.appendChild(buttonRow)
+        candidateGroup.appendChild(choiceContainer)
       })
+
+      candidateGroup.appendChild(button)
+      buttonWrapper.appendChild(candidateGroup)
+      
+      return
+    }
+
+    const button = document.createElement("button")
+    button.type = "button"
+    button.textContent = suggestion.label.replace(/^開始: /, "").replace(/^締切: /, "")
+    button.className = "btn btn-xs btn-outline btn-primary normal-case font-normal"
+
+    button.addEventListener("click", () => {
+      this.insertDateTime(suggestion.label, suggestion.value)
+    })
 
       buttonWrapper.appendChild(button)
     })

--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -131,8 +131,8 @@ export default class extends Controller {
     const endSuggestions = suggestions.filter(suggestion => suggestion.label.includes("締切"))
     const otherSuggestions = suggestions.filter(suggestion => suggestion.label.includes("候補"))
 
-    this.renderSuggestionGroup("受付開始", startSuggestions)
-    this.renderSuggestionGroup("受付締切", endSuggestions)
+    this.renderSuggestionGroup("開始日時", startSuggestions)
+    this.renderSuggestionGroup("締切日時", endSuggestions)
     this.renderSuggestionGroup("候補日", otherSuggestions)
   }
   
@@ -144,7 +144,7 @@ export default class extends Controller {
 
     const heading = document.createElement("p")
     heading.textContent = title
-    heading.className = "text-xs font-semibold text-neutral-500 mb-1"
+    heading.className = "text-xs font-medium text-primary/60 mb-1.5"
 
     const buttonWrapper = document.createElement("div")
     buttonWrapper.className = "flex flex-wrap gap-2"
@@ -157,7 +157,7 @@ export default class extends Controller {
         const button = document.createElement("button")
         button.type = "button"
         button.textContent = `${suggestion.label.replace(/^候補: /, "")} ▾`
-        button.className = "candidate-button btn btn-xs btn-outline btn-primary normal-case font-normal"
+        button.className = "candidate-button btn btn-xs btn-soft btn-info normal-case font-normal"
 
         button.addEventListener("click", () => {
           this.element.querySelectorAll(".candidate-button").forEach((candidateButton) => {
@@ -180,8 +180,8 @@ export default class extends Controller {
 
         const startButton = document.createElement("button")
         startButton.type = "button"
-        startButton.textContent = "開始日時へ"
-        startButton.className = "btn btn-xs btn-outline btn-secondary normal-case font-normal"
+        startButton.textContent = "開始日時にする"
+        startButton.className = "btn btn-xs btn-soft btn-accent normal-case font-normal"
 
         startButton.addEventListener("click", () => {
           this.insertDateTime("開始", suggestion.value)
@@ -189,8 +189,8 @@ export default class extends Controller {
 
         const endButton = document.createElement("button")
         endButton.type = "button"
-        endButton.textContent = "締切日時へ"
-        endButton.className = "btn btn-xs btn-outline btn-accent normal-case font-normal"
+        endButton.textContent = "締切日時にする"
+        endButton.className = "btn btn-xs btn-soft btn-secondary normal-case font-normal"
 
         endButton.addEventListener("click", () => {
           this.insertDateTime("締切", suggestion.value)
@@ -218,7 +218,12 @@ export default class extends Controller {
     const button = document.createElement("button")
     button.type = "button"
     button.textContent = suggestion.label.replace(/^開始: /, "").replace(/^締切: /, "")
-    button.className = "btn btn-xs btn-outline btn-primary normal-case font-normal"
+    
+    if (title === "開始日時") {
+      button.className = "btn btn-xs btn-soft btn-accent normal-case font-normal"
+    } else if (title === "締切日時") {
+      button.className = "btn btn-xs btn-soft btn-secondary normal-case font-normal"
+    }
 
     button.addEventListener("click", () => {
       this.insertDateTime(suggestion.label, suggestion.value)

--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -123,55 +123,54 @@ export default class extends Controller {
 
   // ✨ ボタンを画面に生成
   renderDateSuggestions(suggestions) {
+    if (!this.hasSuggestionsContainerTarget) return
+
     this.suggestionsContainerTarget.innerHTML = ""
+
+    const startSuggestions = suggestions.filter(suggestion => suggestion.label.includes("開始"))
+    const endSuggestions = suggestions.filter(suggestion => suggestion.label.includes("締切"))
+    const otherSuggestions = suggestions.filter(suggestion => suggestion.label.includes("候補"))
+
+    this.renderSuggestionGroup("受付開始", startSuggestions)
+    this.renderSuggestionGroup("受付締切", endSuggestions)
+    this.renderSuggestionGroup("候補日", otherSuggestions)
+  }
+  
+  renderSuggestionGroup(title, suggestions) {
+    if (suggestions.length === 0) return
+
+    const group = document.createElement("div")
+    group.className = "w-full mt-2"
+
+    const heading = document.createElement("p")
+    heading.textContent = title
+    heading.className = "text-xs font-semibold text-neutral-500 mb-1"
+
+    const buttonWrapper = document.createElement("div")
+    buttonWrapper.className = "flex flex-wrap gap-2"
 
     suggestions.forEach((suggestion) => {
       const button = document.createElement("button")
       button.type = "button"
-      button.textContent = suggestion.label
-      button.className ="btn btn-xs btn-outline btn-primary mr-2 mb-2 normal-case font-normal"
-
-      this.suggestionsContainerTarget.appendChild(button)
+      button.textContent = suggestion.label.replace(/^開始: /, "").replace(/^締切: /, "").replace(/^候補: /, "")
+      button.className = "btn btn-xs btn-outline btn-primary normal-case font-normal"
 
       button.addEventListener("click", () => {
         if (suggestion.label.includes("候補")) {
-          // 前回表示した選択肢を削除
-          this.element.querySelectorAll(".date-choice-buttons").forEach(element => element.remove())
-          
-          const choiceContainer = document.createElement("div")
-          choiceContainer.className = "date-choice-buttons flex gap-2 mt-2"
-          
-          const startButton = document.createElement("button")
-          startButton.type = "button"
-          startButton.textContent = "開始日時へ"
-          startButton.className ="btn btn-xs btn-outline btn-primary mr-2 mb-2 normal-case font-normal"
-
-          choiceContainer.appendChild(startButton)
-          
-          startButton.addEventListener("click", () => {
-            this.insertDateTime("開始", suggestion.value)
-          })
-          
-          const endButton = document.createElement("button")
-          endButton.type = "button"
-          endButton.textContent = "締切日時へ"
-          endButton.className ="btn btn-xs btn-outline btn-primary mr-2 mb-2 normal-case font-normal"
-
-          choiceContainer.appendChild(endButton)
-          
-          endButton.addEventListener("click", () => {
-            this.insertDateTime("締切", suggestion.value)
-          })
-
-          button.insertAdjacentElement("afterend", choiceContainer)
+          console.log("候補日が押されました")
         } else {
           this.insertDateTime(suggestion.label, suggestion.value)
         }
       })
+
+      buttonWrapper.appendChild(button)
     })
+
+    group.appendChild(heading)
+    group.appendChild(buttonWrapper)
+    this.suggestionsContainerTarget.appendChild(group)
   }
-  
-  
+
   // ✨ おもてなし入力ロジック
   insertDateTime(label, value) {
     let targetInput = null

--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -5,7 +5,8 @@ export default class extends Controller {
     "titleInput", "titleErrorMessage",
     "urlInput", "fetchButton", "noticeMessage", 
     "startAtInput", "startErrorMessage", 
-    "endAtInput", "errorMessage" 
+    "endAtInput", "errorMessage",
+    "suggestionsContainer" 
   ]
 
   // 画面が表示された時、およびTurboで画面が書き換わった時に毎回確実に動く魔法
@@ -18,8 +19,8 @@ export default class extends Controller {
   connect() {
     // 画面が開いた瞬間、すでに文字が入っていればチェックを1回走らせる
     this.checkAll()
-    
-    // Flatpickrの準備を待って、確実にイベントを仕込む
+
+   // Flatpickrの準備を待って、確実にイベントを仕込む
     this.bindFlatpickr()
   }
 
@@ -71,7 +72,6 @@ export default class extends Controller {
   // タイトルを自動取得するメイン処理
   async fetchTitle() {
     const url = this.urlInputTarget.value.trim()
-
     if (!url) {
       this.showNotice("URLを入力してください", "text-error")
       return
@@ -86,10 +86,14 @@ export default class extends Controller {
       if (response.ok && data.title) {
         this.titleInputTarget.value = data.title
         this.showNotice("タイトルを取得しました！", "text-success text-primary")
-        
+      
         if (typeof this.checkTitle === "function") {
           this.checkTitle()
         }
+
+        // ✨ タイトル取得成功時、日時候補も一緒に裏で取得
+        this.fetchDateSuggestions(url)
+
       } else {
         this.showNotice(data.error || "タイトルが取得できませんでした", "text-neutral-500 font-normal")
       }
@@ -101,7 +105,66 @@ export default class extends Controller {
     }
   }
 
-  // 状態通知メッセージを表示するヘルパーメソッド
+  // ✨ 日時候補の取得
+  async fetchDateSuggestions(url) {
+    try {
+      const response = await fetch(`/api/date_suggestions?url=${encodeURIComponent(url)}`)
+      const data = await response.json()
+
+      if (response.ok && data.suggestions && data.suggestions.length > 0) {
+        this.renderDateSuggestions(data.suggestions)
+      }
+    } catch (error) {
+      console.error("日時候補の取得に失敗しました:", error)
+    }
+  }
+
+  // ✨ ボタンを画面に生成
+  renderDateSuggestions(suggestions) {
+    if (!this.hasSuggestionsContainerTarget) return
+
+    this.suggestionsContainerTarget.innerHTML = "" // 一旦クリア
+
+    suggestions.forEach(suggestion => {
+      const button = document.createElement("button")
+      button.type = "button"
+      // DaisyUIの小さめで控えめなボタンデザイン
+      button.className = "btn btn-xs btn-outline btn-primary mr-2 mb-2 normal-case font-normal"
+      button.textContent = suggestion.label
+
+      // ボタンをクリックしたら、対応する入力欄に値をセット
+      button.addEventListener("click", () => {
+        this.insertDateTime(suggestion.label, suggestion.value)
+      })
+
+      this.suggestionsContainerTarget.appendChild(button)
+    })
+  }
+
+  // ✨ おもてなし入力ロジック
+  insertDateTime(label, value) {
+    let targetInput = null
+
+    // ラベルに「開始」が含まれていれば開始入力欄へ、それ以外（締切や候補）なら締切入力欄を優先
+    if (label.includes("開始") && this.hasStartAtInputTarget) {
+      targetInput = this.startAtInputTarget
+    } else if (this.hasEndAtInputTarget) {
+      targetInput = this.endAtInputTarget
+    }
+
+    if (!targetInput) return
+
+    // Flatpickrインスタンスがあればそこからセット、なければ直接valueにセット
+    if (targetInput._flatpickr) {
+      targetInput._flatpickr.setDate(value, true) // trueで変化イベントを発火させてバリデーションを通す
+    } else {
+      targetInput.value = value
+      // 直接セットした場合は手動でバリデーションを発火
+      this.checkStartDate()
+      this.checkDate()
+    }
+  }
+
   showNotice(message, colorClass) {
     this.noticeMessageTarget.textContent = message
     this.noticeMessageTarget.className = `text-xs font-semibold pl-4 flex items-center gap-1 ${colorClass}`
@@ -153,4 +216,4 @@ export default class extends Controller {
       this.errorMessageTarget.classList.remove("hidden")
     }
   }
-} 
+}

--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -134,7 +134,27 @@ export default class extends Controller {
       this.suggestionsContainerTarget.appendChild(button)
 
       button.addEventListener("click", () => {
-        this.insertDateTime(suggestion.label, suggestion.value)
+        if (suggestion.label.includes("候補")) {
+          // 前回表示した選択肢を削除
+          this.element.querySelectorAll(".date-choice-buttons").forEach(element => element.remove())
+          
+          const choiceContainer = document.createElement("div")
+          choiceContainer.className = "date-choice-buttons flex gap-2 mt-2"
+          
+          const startButton = document.createElement("button")
+          startButton.type = "button"
+          startButton.textContent = "開始日時へ"
+          startButton.className ="btn btn-xs btn-outline btn-primary mr-2 mb-2 normal-case font-normal"
+
+          choiceContainer.appendChild(startButton)
+          button.insertAdjacentElement("afterend", choiceContainer)
+          startButton.addEventListener("click", () => {
+            this.insertDateTime("開始", suggestion.value)
+          })
+          
+        } else {
+          this.insertDateTime(suggestion.label, suggestion.value)
+        }
       })
     })
     

--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -150,57 +150,68 @@ export default class extends Controller {
     buttonWrapper.className = "flex flex-wrap gap-2"
 
     suggestions.forEach((suggestion) => {
-    if (suggestion.label.includes("候補")) {
-      const candidateGroup = document.createElement("div")
-      candidateGroup.className = "flex flex-col items-start gap-1"
+      if (suggestion.label.includes("候補")) {
+        const candidateGroup = document.createElement("div")
+        candidateGroup.className = "flex flex-col items-start gap-1"
 
-      const button = document.createElement("button")
-      button.type = "button"
-      button.textContent = `${suggestion.label.replace(/^候補: /, "")} ▾`
-      button.className = "btn btn-xs btn-outline btn-primary normal-case font-normal"
+        const button = document.createElement("button")
+        button.type = "button"
+        button.textContent = `${suggestion.label.replace(/^候補: /, "")} ▾`
+        button.className = "candidate-button btn btn-xs btn-outline btn-primary normal-case font-normal"
 
-      button.addEventListener("click", () => {
+        button.addEventListener("click", () => {
+          this.element.querySelectorAll(".candidate-button").forEach((candidateButton) => {
+            candidateButton.textContent = candidateButton.textContent.replace("▴", "▾")
+          })
+
+        button.textContent = `${suggestion.label.replace(/^候補: /, "")} ▴`
+
         this.element.querySelectorAll(".date-choice-buttons").forEach(element => element.remove())
 
         const choiceContainer = document.createElement("div")
-        choiceContainer.className = "date-choice-buttons flex flex-col items-center gap-2 mt-2"
+        choiceContainer.className = "date-choice-buttons relative flex flex-col items-center gap-2 mt-2 p-3 rounded-xl bg-white border border-primary/20 shadow-sm"
+
+        const arrow = document.createElement("div")
+        arrow.className = "absolute -top-2 left-5 w-3 h-3 rotate-45 bg-white border-l border-t border-primary/20"
 
         const message = document.createElement("p")
         message.textContent = "どちらに入力しますか？"
-        message.className = "text-xs text-gray-500 "
+        message.className = "text-xs text-gray-500"
 
         const startButton = document.createElement("button")
         startButton.type = "button"
         startButton.textContent = "開始日時へ"
         startButton.className = "btn btn-xs btn-outline btn-secondary normal-case font-normal"
 
+        startButton.addEventListener("click", () => {
+          this.insertDateTime("開始", suggestion.value)
+        })
+
         const endButton = document.createElement("button")
         endButton.type = "button"
         endButton.textContent = "締切日時へ"
         endButton.className = "btn btn-xs btn-outline btn-accent normal-case font-normal"
 
-        const buttonRow = document.createElement("div")
-        buttonRow.className = "flex gap-2"
-
-        startButton.addEventListener("click", () => {
-          this.insertDateTime("開始", suggestion.value)
-        })
-
         endButton.addEventListener("click", () => {
           this.insertDateTime("締切", suggestion.value)
         })
 
+        const buttonRow = document.createElement("div")
+        buttonRow.className = "flex gap-2"
+
         buttonRow.appendChild(startButton)
         buttonRow.appendChild(endButton)
 
+        choiceContainer.appendChild(arrow)
         choiceContainer.appendChild(message)
         choiceContainer.appendChild(buttonRow)
+
         candidateGroup.appendChild(choiceContainer)
       })
 
       candidateGroup.appendChild(button)
       buttonWrapper.appendChild(candidateGroup)
-      
+
       return
     }
 

--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -147,17 +147,28 @@ export default class extends Controller {
           startButton.className ="btn btn-xs btn-outline btn-primary mr-2 mb-2 normal-case font-normal"
 
           choiceContainer.appendChild(startButton)
-          button.insertAdjacentElement("afterend", choiceContainer)
+          
           startButton.addEventListener("click", () => {
             this.insertDateTime("開始", suggestion.value)
           })
           
+          const endButton = document.createElement("button")
+          endButton.type = "button"
+          endButton.textContent = "締切日時へ"
+          endButton.className ="btn btn-xs btn-outline btn-primary mr-2 mb-2 normal-case font-normal"
+
+          choiceContainer.appendChild(endButton)
+          
+          endButton.addEventListener("click", () => {
+            this.insertDateTime("締切", suggestion.value)
+          })
+
+          button.insertAdjacentElement("afterend", choiceContainer)
         } else {
           this.insertDateTime(suggestion.label, suggestion.value)
         }
       })
     })
-    
   }
   
   

--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -111,36 +111,36 @@ export default class extends Controller {
       const response = await fetch(`/api/date_suggestions?url=${encodeURIComponent(url)}`)
       const data = await response.json()
 
-      if (response.ok && data.suggestions && data.suggestions.length > 0) {
+      console.log(data)
+
+      if (response.ok && data.suggestions.length > 0) {
         this.renderDateSuggestions(data.suggestions)
       }
     } catch (error) {
-      console.error("日時候補の取得に失敗しました:", error)
+      console.error(error)
     }
   }
 
   // ✨ ボタンを画面に生成
   renderDateSuggestions(suggestions) {
-    if (!this.hasSuggestionsContainerTarget) return
+    this.suggestionsContainerTarget.innerHTML = ""
 
-    this.suggestionsContainerTarget.innerHTML = "" // 一旦クリア
-
-    suggestions.forEach(suggestion => {
+    suggestions.forEach((suggestion) => {
       const button = document.createElement("button")
       button.type = "button"
-      // DaisyUIの小さめで控えめなボタンデザイン
-      button.className = "btn btn-xs btn-outline btn-primary mr-2 mb-2 normal-case font-normal"
       button.textContent = suggestion.label
+      button.className ="btn btn-xs btn-outline btn-primary mr-2 mb-2 normal-case font-normal"
 
-      // ボタンをクリックしたら、対応する入力欄に値をセット
+      this.suggestionsContainerTarget.appendChild(button)
+
       button.addEventListener("click", () => {
         this.insertDateTime(suggestion.label, suggestion.value)
       })
-
-      this.suggestionsContainerTarget.appendChild(button)
     })
+    
   }
-
+  
+  
   // ✨ おもてなし入力ロジック
   insertDateTime(label, value) {
     let targetInput = null

--- a/app/mailers/welcome_mailer.rb
+++ b/app/mailers/welcome_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class WelcomeMailer < ApplicationMailer
   default from: 'no-reply@fanpocket.fun'
 

--- a/app/services/date_extractor_service.rb
+++ b/app/services/date_extractor_service.rb
@@ -27,7 +27,9 @@ class DateExtractorService
     # 2. 単発日時の抽出
     extract_single_dates(temporary_text, results)
 
-    results.uniq { |r| r[:value] }
+    results
+      .uniq { |r| r[:value] }
+      .sort_by { |r| r[:value] || '' }
   end
 
   private

--- a/app/services/date_extractor_service.rb
+++ b/app/services/date_extractor_service.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+class DateExtractorService
+  # 各種正規表現の定義
+  # 1. 基本となる日時のパターン（年、曜日、時間はオプション）
+  DATE_TIME_PATTERN = %r{(?:\d{4}[年/.-])?\d{1,2}(?:/|月)\d{1,2}日?(?:[(（][^）)]+[)）])?(?:\s*\d{1,2}[:時]\d{2}分?)?}
+
+  # 2. 期間を繋ぐ記号
+  RANGE_SYMBOL = /\s*(?:〜|～|-|─|ー|to)\s*/
+
+  # 3. 期間全体を捉える正規表現
+  RANGE_PATTERN = /(#{DATE_TIME_PATTERN})#{RANGE_SYMBOL}(#{DATE_TIME_PATTERN})/
+
+  def initialize(text)
+    @text = text
+  end
+
+  def call
+    return [] if @text.blank?
+
+    results = []
+    temporary_text = @text.dup
+
+    # 1. 期間の抽出
+    extract_ranges(temporary_text, results)
+
+    # 2. 単発日時の抽出
+    extract_single_dates(temporary_text, results)
+
+    results.uniq { |r| r[:value] }
+  end
+
+  private
+
+  def extract_ranges(text, results)
+    text.scan(RANGE_PATTERN) do |start_str, end_str|
+      results << { label: "開始: #{start_str}", value: parse_to_datetime_string(start_str) }
+      results << { label: "締切: #{end_str}", value: parse_to_datetime_string(end_str) }
+    end
+    text.gsub!(RANGE_PATTERN, '')
+  end
+
+  def extract_single_dates(text, results)
+    text.scan(DATE_TIME_PATTERN) do |match_str|
+      next if match_str.length < 3
+
+      results << { label: "候補: #{match_str}", value: parse_to_datetime_string(match_str) }
+    end
+  end
+
+  def parse_to_datetime_string(str)
+    clean_str = sanitize_date_string(str)
+    clean_str = normalize_datetime_format(clean_str)
+
+    Time.zone.parse(clean_str)&.strftime('%Y-%m-%dT%H:%M')
+  rescue StandardError
+    nil
+  end
+
+  # 文字列のクレンジング（曜日除去、記号の統一）
+  def sanitize_date_string(str)
+    str.gsub(/[(（][^）)]+[)）]/, '')
+       .gsub(/[年月日.-]/, '/')
+       .gsub(/[時分]/, ':')
+       .gsub(%r{/+}, '/')
+       .strip
+  end
+
+  # 年や時間の補完ロジック
+  def normalize_datetime_format(str)
+    str = "#{Time.current.year}/#{str}" unless str.match?(/\A\d{4}/)
+    str = "#{str} 00:00" unless str.match?(/\d{1,2}:\d{2}/)
+    str
+  end
+end

--- a/app/views/watchlists/_form.html.erb
+++ b/app/views/watchlists/_form.html.erb
@@ -35,6 +35,7 @@
     </button>
     
     <p data-watchlist-form-target="noticeMessage" class="text-xs font-semibold pl-4 hidden flex items-center gap-1"></p>
+    <div data-watchlist-form-target="suggestionsContainer" class="mt-2 flex flex-wrap gap-2"></div>
   </div>
 
   <div class="space-y-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,8 +26,12 @@ Rails.application.routes.draw do
   resource :settings, only: [:show]
   
   resources :url_parsers, only: [] do
-  collection do
-    get :fetch_title
+    collection do
+      get :fetch_title
+    end
   end
-end
+  
+  namespace :api do
+    resources :date_suggestions, only: [:index]
+  end
 end

--- a/test/mailers/previews/notification_mailer_preview.rb
+++ b/test/mailers/previews/notification_mailer_preview.rb
@@ -2,45 +2,43 @@
 
 # Preview all emails at http://localhost:3000/rails/mailers/notification_mailer
 class NotificationMailerPreview < ActionMailer::Preview
-
   def send_notice
     NotificationMailer.send_notice(
-      "test@example.com",
-      "ファンミーティング開催決定！",
-      "来月、特別なファンミーティングを開催することが決定しました！詳細はアプリ内をご確認ください。"
+      'test@example.com',
+      'ファンミーティング開催決定！',
+      '来月、特別なファンミーティングを開催することが決定しました！詳細はアプリ内をご確認ください。'
     )
   end
 
   def three_days_ago_notice
     NotificationMailer.three_days_ago_notice(
-      "test@example.com",
-      "限定グッズの事前予約",
-      "会員限定グッズの事前予約受付が、あと3日で締め切りとなります。"
+      'test@example.com',
+      '限定グッズの事前予約',
+      '会員限定グッズの事前予約受付が、あと3日で締め切りとなります。'
     )
   end
 
   def day_before_notice
     NotificationMailer.day_before_notice(
-      "test@example.com",
-      "バースデーメッセージの募集",
-      "大切な推しへのバースデーメッセージの締め切りは明日です！お忘れなきようご注意ください。"
+      'test@example.com',
+      'バースデーメッセージの募集',
+      '大切な推しへのバースデーメッセージの締め切りは明日です！お忘れなきようご注意ください。'
     )
   end
 
   def today_notice
     NotificationMailer.today_notice(
-      "test@example.com",
-      "継続特典の申し込み",
-      "早期継続特典の申し込み締め切りは本日23:59までとなっています。"
+      'test@example.com',
+      '継続特典の申し込み',
+      '早期継続特典の申し込み締め切りは本日23:59までとなっています。'
     )
   end
 
   def start_notice
     NotificationMailer.start_notice(
-      "test@example.com",
-      "夏のフォトコンテスト",
-      "本日より、夏のフォトコンテストの投稿受付がスタートしました！"
+      'test@example.com',
+      '夏のフォトコンテスト',
+      '本日より、夏のフォトコンテストの投稿受付がスタートしました！'
     )
   end
-
 end

--- a/test/mailers/previews/welcome_mailer_preview.rb
+++ b/test/mailers/previews/welcome_mailer_preview.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 # Preview all emails at http://localhost:3000/rails/mailers/welcome_mailer
 class WelcomeMailerPreview < ActionMailer::Preview
   def send_welcome_email
-  # プレビュー表示用に、データベースの最初のユーザー（いなければ仮のユーザー）を渡します
-    user = User.first || User.new(email: "test@example.com")
-    
+    # プレビュー表示用に、データベースの最初のユーザー（いなければ仮のユーザー）を渡します
+    user = User.first || User.new(email: 'test@example.com')
+
     WelcomeMailer.send_welcome_email(user)
   end
 end

--- a/test/mailers/welcome_mailer_test.rb
+++ b/test/mailers/welcome_mailer_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class WelcomeMailerTest < ActionMailer::TestCase
   # test "the truth" do


### PR DESCRIPTION
## 概要
URL先のページ本文から日時候補を抽出し、フォーム上で開始日時・締切日時へ反映できるようにしました。

## 背景
推し活情報のURLから、申込開始日や締切日などを手入力する負担を減らし、登録をより簡単にするためです。

close: #80 

## 変更内容
- Net::HTTP・Nokogiriを利用してURL先のHTML本文を取得
- 日時候補を「開始日時」「締切日時」「候補日」に分類表示
- 候補日から開始日時・締切日時を選択できるUIを追加
- 吹き出し風UI・色分けなど表示デザインを調整
- 日時候補を時系列順に並び替えるよう変更
- `URI.open` を `Net::HTTP` に変更し、RuboCopの警告を解消

## 確認方法
- URLを入力し、「タイトルを自動取得する」をクリック
- タイトルが取得されること
- 日時候補が「開始日時」「締切日時」「候補日」に分類表示されること
- 開始日時・締切日時のボタンを押すと各入力欄へ反映されること
- 候補日を押すと入力先選択UIが表示されること
- 「開始日時にする」「締切日時にする」を押すと各入力欄へ反映されること
- 日時候補が時系列順に表示されること
- `bundle exec rubocop` を実行し、警告が出ないことを確認

## 影響範囲
- 予定登録画面
- URLからの日時候補取得機能
- 既存の登録・編集・削除機能への影響なし

## スクリーンショット
- 日時候補の分類表示
- 候補日選択時の吹き出しUI
<img width="1138" height="972" alt="image" src="https://github.com/user-attachments/assets/365a3e9f-b3d5-4dd1-b6ac-60a3cac61779" />

## 補足
- MetaInspectorでは本文取得ができなかったため、Net::HTTP・Nokogiriを利用した実装へ変更しました。
- 候補日は開始日時・締切日時のどちらにも該当する可能性があるため、自動で入力先を決定せず、ユーザーが選択できる仕様としました。