### PR TITLE
【仕様変更/バグ修正】開始日時の過去容認化による候補抽出UXの最大化 ＆ 日時矛盾バリデーションの復活

### DIFF
--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -4,15 +4,13 @@ export default class extends Controller {
   static targets = [ 
     "titleInput", "titleErrorMessage",
     "urlInput", "fetchButton", "noticeMessage", 
-    "startAtInput", "startErrorMessage", 
-    "endAtInput", "errorMessage",
+    "startAtInput", "endAtInput", "endAtRealtimeError",
     "suggestionsContainer" 
   ]
 
   // 画面が表示された時、およびTurboで画面が書き換わった時に毎回確実に動く魔法
   initialize() {
     this.checkTitle = this.checkTitle.bind(this)
-    this.checkStartDate = this.checkStartDate.bind(this)
     this.checkDate = this.checkDate.bind(this)
   }
 
@@ -281,35 +279,48 @@ export default class extends Controller {
 
   // 開始日時のチェック
   checkStartDate() {
-    if (!this.hasStartAtInputTarget || !this.hasStartErrorMessageTarget) return
-    const inputDateValue = this.startAtInputTarget.value
-    if (!inputDateValue) return
-
-    const normalizedString = inputDateValue.replace(/\//g, '-')
-    const inputDate = new Date(normalizedString)
-    const now = new Date()
-
-    if (inputDate >= now) {
-      this.startErrorMessageTarget.classList.add("hidden")
-    } else {
-      this.startErrorMessageTarget.classList.remove("hidden")
-    }
+    this.checkDate()
   }
 
-  // 締切日時のチェック
+  // 締切日時のチェック 
   checkDate() {
-    if (!this.hasEndAtInputTarget || !this.hasErrorMessageTarget) return
-    const inputDateValue = this.endAtInputTarget.value
-    if (!inputDateValue) return
+    if (!this.hasEndAtInputTarget || !this.hasEndAtRealtimeErrorTarget) return
 
-    const normalizedString = inputDateValue.replace(/\//g, '-')
-    const inputDate = new Date(normalizedString)
+    const endAtValue = this.endAtInputTarget.value
+    if (!endAtValue) {
+      this.endAtRealtimeErrorTarget.classList.add("hidden")
+      return
+    }
+
+    const endAt = new Date(endAtValue.replace(/\//g, "-"))
     const now = new Date()
 
-    if (inputDate >= now) {
-      this.errorMessageTarget.classList.add("hidden")
+    let errorMessage = ""
+
+    if (endAt < now) {
+      errorMessage = "締切日時は未来の日時を選択してください"
+    }
+
+    if (this.hasStartAtInputTarget) {
+      const startAtValue = this.startAtInputTarget.value
+
+      if (startAtValue) {
+        const startAt = new Date(startAtValue.replace(/\//g, "-"))
+
+        if (endAt <= startAt) {
+          errorMessage = "締切日時は開始日時より後の日時を選択してください"
+        }
+      }
+    }
+
+    if (errorMessage) {
+      this.endAtRealtimeErrorTarget.innerHTML = `
+        <span class="material-symbols-outlined text-sm">info</span>
+        ${errorMessage}
+      `
+      this.endAtRealtimeErrorTarget.classList.remove("hidden")
     } else {
-      this.errorMessageTarget.classList.remove("hidden")
+      this.endAtRealtimeErrorTarget.classList.add("hidden")
     }
   }
 }

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -91,10 +91,9 @@ class Watchlist < ApplicationRecord
   def start_at_or_end_at_must_be_present
     return unless start_at.blank? && end_at.blank?
 
-    errors.add(:base, '開始日時または締切日時のどちらかは入力してください')
+    errors.add(:base, :start_at_or_end_at_blank)
   end
 
-  # 両方入力されている場合のみ、日時の矛盾（開始日 < 締切日）をチェック
   def end_at_must_be_after_start_at
     return unless start_at.present? && end_at.present? && end_at <= start_at
 
@@ -104,6 +103,6 @@ class Watchlist < ApplicationRecord
   def end_at_must_be_future
     return unless end_at.present? && end_at < Time.current
 
-    errors.add(:end_at, 'は未来の日時を選択してください')
+    errors.add(:end_at, :must_be_future)
   end
 end

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -11,8 +11,8 @@ class Watchlist < ApplicationRecord
   VALID_URL_REGEX = %r{\Ahttps?://\S+\z}
   validates :url, allow_blank: true, format: { with: VALID_URL_REGEX }
 
-  validate :start_at_must_be_future, on: :create
-  validate :end_at_must_be_future
+  validate :end_at_must_be_future, on: :create
+  validate :end_at_must_be_after_start_at
 
   # 「これからの予定」を取得するスコープ
   scope :upcoming, lambda {
@@ -99,12 +99,6 @@ class Watchlist < ApplicationRecord
     return unless start_at.present? && end_at.present? && end_at <= start_at
 
     errors.add(:end_at, :must_be_after_start_at)
-  end
-
-  def start_at_must_be_future
-    return unless start_at.present? && start_at < Time.current
-
-    errors.add(:start_at, 'は未来の日時を選択してください')
   end
 
   def end_at_must_be_future

--- a/app/views/watchlists/_form.html.erb
+++ b/app/views/watchlists/_form.html.erb
@@ -78,7 +78,7 @@
       <%= f.text_field :end_at, data: { controller: "flatpickr", watchlist_form_target: "endAtInput" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:end_at].any?}", placeholder: "年/月/日 --:--" %>
       
       <% if watchlist.errors[:end_at].any? %>
-        <p data-watchlist-form-target="errorMessage" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
+        <p  class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
           <span class="material-symbols-outlined text-sm">info</span>
           <%= watchlist.errors.full_messages_for(:end_at).first %>
         </p>

--- a/app/views/watchlists/_form.html.erb
+++ b/app/views/watchlists/_form.html.erb
@@ -62,13 +62,6 @@
         <span class="material-symbols-outlined text-lg">calendar_today</span>開始日時
       <% end %>
       <%= f.text_field :start_at, data: { controller: "flatpickr", watchlist_form_target: "startAtInput" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:start_at].any?}", placeholder: "年/月/日 --:--" %>
-
-      <% if watchlist.errors[:start_at].any? %>
-        <p data-watchlist-form-target="startErrorMessage" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
-          <span class="material-symbols-outlined text-sm">info</span>
-          <%= watchlist.errors.full_messages_for(:start_at).first %>
-        </p>
-      <% end %>
     </div>
 
     <div class="space-y-3">
@@ -78,11 +71,12 @@
       <%= f.text_field :end_at, data: { controller: "flatpickr", watchlist_form_target: "endAtInput" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:end_at].any?}", placeholder: "年/月/日 --:--" %>
       
       <% if watchlist.errors[:end_at].any? %>
-        <p  class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
+        <p data-watchlist-form-target="endAtRealtimeError" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
           <span class="material-symbols-outlined text-sm">info</span>
           <%= watchlist.errors.full_messages_for(:end_at).first %>
         </p>
       <% end %>
+    
     </div>
   </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,12 +11,13 @@ ja:
     errors:
       models:
         watchlist:
-          base:
-            start_at_or_end_at_blank: "開始日時または締切日時のどちらかは入力してください"
           attributes:
+            base:
+              start_at_or_end_at_blank: "開始日時または締切日時のどちらかは入力してください"
             title:
               blank: "を入力してください"
             url:
               invalid: "は有効な形式（http/https〜）で入力してください"
             end_at:
               must_be_after_start_at: "は開始日時より後の日時を選択してください"
+              must_be_future: "は未来の日時を選択してください"


### PR DESCRIPTION
## 概要
開始日時の過去制限を撤廃し、締切日時との矛盾チェックを復活しました。
あわせて、日時入力エラーを修正した際にメッセージが消えるようUXを改善しました。

## 背景
close #114

日付候補抽出機能で、すでに開始済みのイベントを登録したい場合に、開始日時が過去であることで登録できない課題がありました。
また、開始日時より前の締切日時を保存できてしまう状態だったため、日時の整合性を担保する必要がありました。

## 変更内容
- 開始日時の過去制限を撤廃
- 締切日時の過去制限を新規登録時のみに変更
- 開始日時より前の締切日時を保存できないようバリデーションを追加
- バリデーションエラーメッセージを `config/locales/ja.yml` で管理
- 日時入力を修正した際に、エラーメッセージがリアルタイムで消えるようStimulusを修正
- 開始日時の過去チェックに関する不要なエラー表示を削除

## 確認方法
- 開始日時を過去、締切日時を未来にして新規登録できること
- 開始日時を未来、締切日時を過去にして新規登録できないこと
- 開始日時を未来、締切日時を開始日時より前にして新規登録できないこと
- 上記エラー表示後、正しい日時に修正すると送信前にエラーメッセージが消えること
- 編集時は締切日時が過去でも更新できること
- 開始日時または締切日時のどちらも未入力の場合、エラーメッセージが表示されること

## 影響範囲
- 予定登録画面
- 予定編集画面
- 日時候補抽出からの登録導線
- 通知対象となる締切日時のバリデーション

編集時は、締切後に対応済みへ変更したり、メモ・URL・タイトルを修正できるよう、過去の締切日時でも更新可能としています。

## スクリーンショット
<img width="1054" height="763" alt="image" src="https://github.com/user-attachments/assets/276459cb-e626-4d38-b65c-b4a4a9f996eb" />
<img width="1097" height="697" alt="image" src="https://github.com/user-attachments/assets/503536bb-ddc6-45aa-9237-9b5438d93367" />


## 補足
開始日時は、開催中・開始済みイベントも登録できるよう過去日時を許可しています。
一方で、締切日時の過去制限は新規登録時のみ残し、通知対象にならない予定が新規登録されることを防いでいます。