### PR TITLE
スケジュールへの受付種別（抽選/先着/受注/一般）および受付詳細（1次/2次等）の追加

### DIFF
--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install gems
         run: bundle install
 
+      - name: Run database migrations
+        run: bundle exec rails db:migrate
+
       # 4. 【朝7時通知】当日・開始日タスクの実行
       # 💡 inputs.notification_type に修正（最新の仕様に準拠）
       - name: Run Same Day Notifications (7:00 JST)

--- a/app/controllers/watchlists_controller.rb
+++ b/app/controllers/watchlists_controller.rb
@@ -69,11 +69,11 @@ class WatchlistsController < ApplicationController
       :title,
       :memo,
       :url,
-      :start_at, 
-      :end_at, 
-      :is_done, 
-      :reception_type, 
+      :start_at,
+      :end_at,
+      :is_done,
+      :reception_type,
       :reception_detail
-      )
+    )
   end
 end

--- a/app/controllers/watchlists_controller.rb
+++ b/app/controllers/watchlists_controller.rb
@@ -65,6 +65,15 @@ class WatchlistsController < ApplicationController
   end
 
   def watchlist_params
-    params.require(:watchlist).permit(:title, :memo, :url, :start_at, :end_at, :is_done)
+    params.require(:watchlist).permit(
+      :title,
+      :memo,
+      :url,
+      :start_at, 
+      :end_at, 
+      :is_done, 
+      :reception_type, 
+      :reception_detail
+      )
   end
 end

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -18,31 +18,31 @@ class Watchlist < ApplicationRecord
     not_set: 0,     # 指定なし
     lottery: 1,     # 抽選受付
     first_come: 2,  # 先着受付
-    made_to_order: 3,  # 受注販売
-    general: 4      # 一般販売
-  },  default: :not_set
+    made_to_order: 3, # 受注販売
+    general: 4 # 一般販売
+  }, default: :not_set
   validates :reception_detail, length: { maximum: 20 }, allow_blank: true
 
   def reception_type_label
     I18n.t(
       "enums.watchlist.reception_type.#{reception_type}"
-   )
+    )
   end
 
   def reception_label_text
-    if reception_detail.present? && reception_type != "not_set"
+    if reception_detail.present? && reception_type != 'not_set'
       "【#{reception_detail}#{reception_type_label}】"
     elsif reception_detail.present?
       "【#{reception_detail}】"
-    elsif reception_type != "not_set"
+    elsif reception_type != 'not_set'
       "【#{reception_type_label}】"
     end
   end
 
   def display_title
-   "#{reception_label_text}#{title}"
+    "#{reception_label_text}#{title}"
   end
-  
+
   # 「これからの予定」を取得するスコープ
   scope :upcoming, lambda {
     target_date_sql = <<~SQL

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -30,17 +30,17 @@ class Watchlist < ApplicationRecord
   end
 
   def reception_label_text
-    [
-      reception_detail.presence&.then { |detail| "【#{detail}】" },
-      reception_type != "not_set" ? "【#{reception_type_label}】" : nil
-    ].compact.join
+    if reception_detail.present? && reception_type != "not_set"
+      "【#{reception_detail}#{reception_type_label}】"
+    elsif reception_detail.present?
+      "【#{reception_detail}】"
+    elsif reception_type != "not_set"
+      "【#{reception_type_label}】"
+    end
   end
-  
-  def notification_content(watchlist, message)
-    [
-      reception_label_text(watchlist).presence,
-      message
-    ].compact.join("\n")
+
+  def display_title
+   "#{reception_label_text}#{title}"
   end
   
   # 「これからの予定」を取得するスコープ

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -14,6 +14,15 @@ class Watchlist < ApplicationRecord
   validate :end_at_must_be_future, on: :create
   validate :end_at_must_be_after_start_at
 
+  enum :reception_type, {
+    not_set: 0,     # 指定なし
+    lottery: 1,     # 抽選受付
+    first_come: 2,  # 先着受付
+    made_to_order: 3,  # 受注販売
+    general: 4      # 一般販売
+  },  default: :not_set
+  validates :reception_detail, length: { maximum: 20 }, allow_blank: true
+
   # 「これからの予定」を取得するスコープ
   scope :upcoming, lambda {
     target_date_sql = <<~SQL

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -23,6 +23,12 @@ class Watchlist < ApplicationRecord
   },  default: :not_set
   validates :reception_detail, length: { maximum: 20 }, allow_blank: true
 
+  def reception_type_label
+    I18n.t(
+      "enums.watchlist.reception_type.#{reception_type}"
+   )
+  end
+  
   # 「これからの予定」を取得するスコープ
   scope :upcoming, lambda {
     target_date_sql = <<~SQL

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -28,6 +28,20 @@ class Watchlist < ApplicationRecord
       "enums.watchlist.reception_type.#{reception_type}"
    )
   end
+
+  def reception_label_text
+    [
+      reception_detail.presence&.then { |detail| "【#{detail}】" },
+      reception_type != "not_set" ? "【#{reception_type_label}】" : nil
+    ].compact.join
+  end
+  
+  def notification_content(watchlist, message)
+    [
+      reception_label_text(watchlist).presence,
+      message
+    ].compact.join("\n")
+  end
   
   # 「これからの予定」を取得するスコープ
   scope :upcoming, lambda {

--- a/app/views/watchlists/_form.html.erb
+++ b/app/views/watchlists/_form.html.erb
@@ -39,6 +39,47 @@
   </div>
 
   <div class="space-y-3">
+    <%= f.label :reception_type, "種別",
+      class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" %>
+
+    <div class="flex flex-wrap gap-3">
+      <label class="flex items-center gap-2 text-sm">
+        <%= f.radio_button :reception_type, "not_set", class: "radio radio-info" %>
+        指定なし
+      </label>
+
+      <label class="flex items-center gap-2 text-sm">
+        <%= f.radio_button :reception_type, "lottery", class: "radio radio-info" %>
+        抽選
+      </label>
+
+      <label class="flex items-center gap-2 text-sm">
+        <%= f.radio_button :reception_type, "first_come", class: "radio radio-info" %>
+        先着
+      </label>
+
+      <label class="flex items-center gap-2 text-sm">
+        <%= f.radio_button :reception_type, "made_to_order", class: "radio radio-info" %>
+        受注販売
+      </label>
+
+      <label class="flex items-center gap-2 text-sm">
+        <%= f.radio_button :reception_type, "general", class: "radio radio-info" %>
+        一般販売
+      </label>
+    </div>
+  </div>
+
+  <div class="space-y-3">
+    <%= f.label :reception_detail, "種別詳細",
+      class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" %>
+
+    <%= f.text_field :reception_detail,
+      class: "w-full h-14 px-6 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
+      placeholder: "FC1次、入金など" %>
+  </div>
+
+  <div class="space-y-3">
     <%= f.label :title, "タイトル", class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" %>
     
     <%= f.text_field :title, 

--- a/app/views/watchlists/_watchlist_card.html.erb
+++ b/app/views/watchlists/_watchlist_card.html.erb
@@ -1,8 +1,19 @@
 <%= link_to watchlist_path(watchlist), class: "block transition-transform duration-200 active:scale-[0.98]" do %>
   <div class="relative group bg-white rounded-xl p-5 sticky-note-shadow flex items-center justify-between border-l-8 <%= is_past ? 'border-gray-300' : 'border-[#B6E0F3]' %>">
     <div class="flex-1 pr-4 <%= 'opacity-60' if is_past || watchlist.is_done? %>">
-      <p class="font-label text-xs text-on-surface-variant/70 mb-1">
+      <p class="font-label text-xs text-on-surface-variant/70 mb-2">
         <%= watchlist.start_at&.strftime("%Y.%m.%d %H:%M") %>
+        <% if watchlist.reception_type != "not_set" %>
+          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
+            <%= watchlist.reception_type_label %>
+          </span>
+        <% end %>
+
+        <% if watchlist.reception_detail.present? %>
+          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
+            <%= watchlist.reception_detail %>
+          </span>
+        <% end %>
       </p>
       <h3 class="font-headline font-bold text-lg text-on-surface leading-tight line-clamp-2 break-all">
         <%= watchlist.title %>

--- a/app/views/watchlists/_watchlist_card.html.erb
+++ b/app/views/watchlists/_watchlist_card.html.erb
@@ -3,17 +3,19 @@
     <div class="flex-1 pr-4 <%= 'opacity-60' if is_past || watchlist.is_done? %>">
       <p class="font-label text-xs text-on-surface-variant/70 mb-2">
         <%= watchlist.start_at&.strftime("%Y.%m.%d %H:%M") %>
+        
+         <% if watchlist.reception_detail.present? %>
+          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
+            <%= watchlist.reception_detail %>
+          </span>
+        <% end %>
+        
         <% if watchlist.reception_type != "not_set" %>
           <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
             <%= watchlist.reception_type_label %>
           </span>
         <% end %>
 
-        <% if watchlist.reception_detail.present? %>
-          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
-            <%= watchlist.reception_detail %>
-          </span>
-        <% end %>
       </p>
       <h3 class="font-headline font-bold text-lg text-on-surface leading-tight line-clamp-2 break-all">
         <%= watchlist.title %>

--- a/app/views/watchlists/index.html.erb
+++ b/app/views/watchlists/index.html.erb
@@ -1,7 +1,7 @@
 <main class="max-w-screen-xl mx-auto px-6 mt-16 pb-40">
   <!-- これからの予定セクション -->
   <!-- Date Header Section -->
-  <div class="mb-12 pt-4 text-center"> <%# pt-4 を追加してヘッダーとの距離を微調整 %>
+  <div class="mb-12 pt-4 text-center"> 
     <h2 class="font-headline font-extrabold text-3xl tracking-tight text-primary">これからの予定</h2>
   </div>
   <div class="mb-6">

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -23,6 +23,19 @@
 
   <!-- Title Section -->
   <section class="bg-white p-8 rounded-3xl puffy-shadow relative overflow-hidden border-l-[12px] <%= ( @watchlist.end_at && @watchlist.end_at < Time.current ) ? 'border-gray-300' : 'border-[#B6E0F3]' %>">
+    <p class="font-label text-xs text-on-surface-variant/70 mb-3 flex flex-wrap gap-2">
+      <% if @watchlist.reception_type != "not_set" %>
+          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-sm font-bold px-3 py-1 rounded-full tracking-wider">
+            <%= @watchlist.reception_type_label %>
+          </span>
+        <% end %>
+
+        <% if @watchlist.reception_detail.present? %>
+          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-sm font-bold px-3 py-1 rounded-full tracking-wider">
+            <%= @watchlist.reception_detail %>
+          </span>
+        <% end %>
+      </p>
     <h2 class="font-headline font-extrabold text-3xl text-on-surface leading-tight tracking-tight relative z-10 break-words whitespace-normal">
       <%= @watchlist.title %>
     </h2>

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -24,17 +24,18 @@
   <!-- Title Section -->
   <section class="bg-white p-8 rounded-3xl puffy-shadow relative overflow-hidden border-l-[12px] <%= ( @watchlist.end_at && @watchlist.end_at < Time.current ) ? 'border-gray-300' : 'border-[#B6E0F3]' %>">
     <p class="font-label text-xs text-on-surface-variant/70 mb-3 flex flex-wrap gap-2">
+      <% if @watchlist.reception_detail.present? %>
+        <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-sm font-bold px-3 py-1 rounded-full tracking-wider">
+          <%= @watchlist.reception_detail %>
+        </span>
+      <% end %>
+
       <% if @watchlist.reception_type != "not_set" %>
           <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-sm font-bold px-3 py-1 rounded-full tracking-wider">
             <%= @watchlist.reception_type_label %>
           </span>
         <% end %>
 
-        <% if @watchlist.reception_detail.present? %>
-          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-sm font-bold px-3 py-1 rounded-full tracking-wider">
-            <%= @watchlist.reception_detail %>
-          </span>
-        <% end %>
       </p>
     <h2 class="font-headline font-extrabold text-3xl text-on-surface leading-tight tracking-tight relative z-10 break-words whitespace-normal">
       <%= @watchlist.title %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,3 +21,11 @@ ja:
             end_at:
               must_be_after_start_at: "は開始日時より後の日時を選択してください"
               must_be_future: "は未来の日時を選択してください"
+  enums:
+    watchlist:
+      reception_type:
+        not_set: "指定なし"
+        lottery: "抽選"
+        first_come: "先着"
+        made_to_order: "受注販売"
+        general: "一般販売"

--- a/db/migrate/20260707144916_add_reception_fields_to_watchlists.rb
+++ b/db/migrate/20260707144916_add_reception_fields_to_watchlists.rb
@@ -1,0 +1,6 @@
+class AddReceptionFieldsToWatchlists < ActiveRecord::Migration[7.1]
+  def change
+    add_column :watchlists, :reception_type, :integer, null: false, default: 0
+    add_column :watchlists, :reception_detail, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_08_021647) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_07_144916) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -37,6 +37,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_08_021647) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "reception_type", default: 0, null: false
+    t.string "reception_detail"
     t.index ["user_id"], name: "index_watchlists_on_user_id"
   end
 

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -102,7 +102,7 @@ namespace :notification do
         user_email = user.email
         title      = watchlist.title
         content    = "気になっている「#{watchlist.display_title}」の開始は本日です。詳細をチェックしてみませんか？"
-        
+
         NotificationMailer.start_notice(user_email, title, content).deliver_now
         puts "当日開始通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
 

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -14,10 +14,7 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = [
-           watchlist.reception_label_text.presence,
-            "気になっている「#{watchlist.title}」の締め切りまであと3日です。忘れないうちにチェックしてみませんか？"
-            ].compact.join("\n")
+        content    = "気になっている「#{watchlist.display_title}」の締め切りまであと3日です。忘れないうちにチェックしてみませんか？"
 
         NotificationMailer.three_days_ago_notice(user_email, title, content).deliver_now
         puts "通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
@@ -45,10 +42,7 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = [
-          watchlist.reception_label_text.presence,
-          "気になっている「#{watchlist.title}」の締め切りは明日です。大切な予定を見逃さないようにご確認ください。"
-          ].compact.join("\n")
+        content    = "気になっている「#{watchlist.display_title}」の締め切りは明日です。大切な予定を見逃さないようにご確認ください。"
 
         NotificationMailer.day_before_notice(user_email, title, content).deliver_now
         puts "前日通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
@@ -79,10 +73,7 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = [
-          watchlist.reception_label_text.presence,
-          "気になっている「#{watchlist.title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
-          ].compact.join("\n")
+        content    = "気になっている「#{watchlist.display_title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
 
         NotificationMailer.today_notice(user_email, title, content).deliver_now
         puts "当日締切通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
@@ -110,11 +101,8 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = [
-          watchlist.reception_label_text.presence,
-          "気になっている「#{watchlist.title}」の開始は本日です。詳細をチェックしてみませんか？"
-          ].compact.join("\n")
-
+        content    = "気になっている「#{watchlist.display_title}」の開始は本日です。詳細をチェックしてみませんか？"
+        
         NotificationMailer.start_notice(user_email, title, content).deliver_now
         puts "当日開始通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
 

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -14,7 +14,10 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = "気になっている「#{watchlist.title}」の締め切りまであと3日です。忘れないうちにチェックしてみませんか？"
+        content    = [
+           watchlist.reception_label_text.presence,
+            "気になっている「#{watchlist.title}」の締め切りまであと3日です。忘れないうちにチェックしてみませんか？"
+            ].compact.join("\n")
 
         NotificationMailer.three_days_ago_notice(user_email, title, content).deliver_now
         puts "通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
@@ -42,7 +45,10 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = "気になっている「#{watchlist.title}」の締め切りは明日です。大切な予定を見逃さないようにご確認ください。"
+        content    = [
+          watchlist.reception_label_text.presence,
+          "気になっている「#{watchlist.title}」の締め切りは明日です。大切な予定を見逃さないようにご確認ください。"
+          ].compact.join("\n")
 
         NotificationMailer.day_before_notice(user_email, title, content).deliver_now
         puts "前日通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
@@ -73,7 +79,10 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = "気になっている「#{watchlist.title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
+        content    = [
+          watchlist.reception_label_text.presence,
+          "気になっている「#{watchlist.title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
+          ].compact.join("\n")
 
         NotificationMailer.today_notice(user_email, title, content).deliver_now
         puts "当日締切通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
@@ -101,7 +110,10 @@ namespace :notification do
       begin
         user_email = user.email
         title      = watchlist.title
-        content    = "気になっている「#{watchlist.title}」の開始は本日です。詳細をチェックしてみませんか？"
+        content    = [
+          watchlist.reception_label_text.presence,
+          "気になっている「#{watchlist.title}」の開始は本日です。詳細をチェックしてみませんか？"
+          ].compact.join("\n")
 
         NotificationMailer.start_notice(user_email, title, content).deliver_now
         puts "当日開始通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"


### PR DESCRIPTION
## 概要
ウォッチリストに受付種別・種別詳細を追加し、一覧・詳細・通知メールで受付情報を表示できるようにしました。

## 背景
受付種別（抽選・先着・受注販売など）や受付詳細（FC1次・入金など）をタイトルとは別に管理し、予定の視認性を向上させるため。
（close #95 ）

## 変更内容
- Watchlistsテーブルに `reception_type` と `reception_detail` を追加
- `Watchlist`モデルにenum・バリデーションを追加
- 受付情報の表示用メソッド（`reception_type_label`、`reception_label_text`、`display_title`）を追加
- 登録・編集フォームに受付種別・受付詳細の入力欄を追加
- 一覧・詳細画面に受付情報をバッジ表示
- 一覧・詳細・通知メールで受付情報の表示順を統一
- 通知メールに受付情報を表示するよう変更
- GitHub Actions実行前に `db:migrate` を追加

## 確認方法
- [x] 受付種別・受付詳細を入力して登録できること
- [x] 編集時に受付情報を更新できること
- [x] 一覧画面で受付情報が表示されること
- [x] 詳細画面で受付情報が表示されること
- [x] 受付詳細のみ入力した場合でも表示されること
- [x] 受付情報未入力時は表示されないこと
- [x] 通知メールに受付情報が表示されること
- [x] GitHub Actionsから通知メールが正常に送信されること

## 影響範囲
### 影響がある画面・機能
- ウォッチリスト登録・編集
- ウォッチリスト一覧
- ウォッチリスト詳細
- 通知メール
- GitHub Actions（通知処理）

### 影響がないこと
- ログイン・認証機能
- 通知タイミング・通知条件

## スクリーンショット
- 一覧画面
<img width="1912" height="997" alt="image" src="https://github.com/user-attachments/assets/8973356b-2feb-484f-bca0-b9bc5457e91e" />

- 詳細画面
<img width="1919" height="998" alt="image" src="https://github.com/user-attachments/assets/fad5a762-50a4-4035-ad0b-ccbe6217436f" />

- 通知メール
<img width="1757" height="804" alt="image" src="https://github.com/user-attachments/assets/95331377-0db4-4a89-a189-9d1d3587bb1d" />

## 補足
- 受付情報は「種別詳細 → 種別」の順で表示するよう統一しました。
- 表示用ロジックは `Watchlist` モデルへ集約し、一覧・詳細・通知メールで共通利用できるようにしました。
- 今後、LINE通知や通知処理の改善時にも同じ表示ロジックを利用できる構成を意識しています。