### PR TITLE
レスポンシブUIの改善

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,26 +1,57 @@
-<nav class="fixed bottom-0 left-0 w-full flex justify-around items-center px-8 py-3 pb-safe z-50 rounded-t-3xl shadow-[0_-4px_20px_rgba(0,0,0,0.1)] transition-colors" style="background-color: white">
-  
-  <%# コレクション（一覧）へのリンク %>
-  <%= link_to watchlists_path, class: "flex flex-col items-center justify-center transition-all group" do %>
-    <%# アクティブ時は濃い青、非アクティブ時は少し透過させる %>
-    <span class="material-symbols-outlined text-3xl <%= action_name == 'index' ? 'text-[#2d6489]' : 'text-[#2d6489]/50' %>" 
-          style="<%= 'font-variation-settings: \'FILL\' 1;' if action_name == 'index' %>">
-    lists
-    </span>
-    <span class="text-[10px] font-bold mt-0.5 <%= action_name == 'index' ? 'text-[#2d6489]' : 'text-[#2d6489]/50' %>">
-      これからの予定
-    </span>
-  <% end %>
+<nav
+  class="fixed bottom-0 left-0 z-50
+         w-full
+         bg-white
+         rounded-t-3xl
+         shadow-[0_-4px_20px_rgba(0,0,0,0.1)]
+         transition-colors"
+  aria-label="メインナビゲーション">
 
-  <%# 設定へのリンク %>
-  <%= link_to settings_path, class: "flex flex-col items-center justify-center transition-all group" do %>
-    <span class="material-symbols-outlined text-3xl <%= controller_name == 'settings' ? 'text-[#2d6489]' : 'text-[#2d6489]/50' %>"
-          style="<%= 'font-variation-settings: \'FILL\' 1;' if controller_name == 'settings' %>">
-      settings
-    </span>
-    <span class="text-[10px] font-bold mt-0.5 <%= controller_name == 'settings' ? 'text-[#2d6489]' : 'text-[#2d6489]/50' %>">
-      設定
-    </span>
-  <% end %>
-  
+  <div class="w-full max-w-3xl mx-auto flex items-center justify-around px-4 sm:px-8 py-2 pb-safe">
+    <%# コレクション（一覧）へのリンク %>
+    <%= link_to watchlists_path,
+                class: "group
+                        flex flex-1 flex-col items-center justify-center
+                        min-h-14 px-3
+                        rounded-2xl
+                        transition-all
+                        active:bg-[#B6E0F3]/30
+                        focus-visible:outline
+                        focus-visible:outline-2
+                        focus-visible:outline-offset-2
+                        focus-visible:outline-[#2d6489]" do %>
+      <span
+        class="material-symbols-outlined text-3xl <%= action_name == "index" ? "text-[#2d6489]" : "text-[#2d6489]/50" %>"
+        style="<%= "font-variation-settings: 'FILL' 1;" if action_name == "index" %>">
+        lists
+      </span>
+
+      <span class="text-[10px] font-bold mt-0.5 <%= action_name == "index" ? "text-[#2d6489]" : "text-[#2d6489]/50" %>">
+        これからの予定
+      </span>
+    <% end %>
+
+    <%# 設定へのリンク %>
+    <%= link_to settings_path,
+                class: "group
+                        flex flex-1 flex-col items-center justify-center
+                        min-h-14 px-3
+                        rounded-2xl
+                        transition-all
+                        active:bg-[#B6E0F3]/30
+                        focus-visible:outline
+                        focus-visible:outline-2
+                        focus-visible:outline-offset-2
+                        focus-visible:outline-[#2d6489]" do %>
+      <span
+        class="material-symbols-outlined text-3xl <%= controller_name == "settings" ? "text-[#2d6489]" : "text-[#2d6489]/50" %>"
+        style="<%= "font-variation-settings: 'FILL' 1;" if controller_name == "settings" %>">
+        settings
+      </span>
+
+      <span class="text-[10px] font-bold mt-0.5 <%= controller_name == "settings" ? "text-[#2d6489]" : "text-[#2d6489]/50" %>">
+        設定
+      </span>
+    <% end %>
+  </div>
 </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,21 +2,42 @@
 <html data-theme="night">
   <head>
     <title>App</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
 
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
-    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700;800&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet"/>
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700;800&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
   </head>
-    <div class="fixed z-0 blur-[100px] rounded-full bg-[#e0f2fe] opacity-50 w-[500px] h-[500px] -top-20 -right-20 pointer-events-none"></div>
-    <div class="fixed z-0 blur-[100px] rounded-full bg-[#e0f2fe] opacity-40 w-[400px] h-[400px] -bottom-20 -left-20 pointer-events-none"></div>
-  <body>
+
+  <body class="relative min-h-screen overflow-x-hidden">
+    <%# 背景装飾 %>
+    <div
+      class="fixed z-0 blur-[100px] rounded-full bg-[#e0f2fe] opacity-50
+             w-72 h-72 md:w-[500px] md:h-[500px]
+             -top-20 -right-20 pointer-events-none"
+      aria-hidden="true">
+    </div>
+
+    <div
+      class="fixed z-0 blur-[100px] rounded-full bg-[#e0f2fe] opacity-40
+             w-64 h-64 md:w-[400px] md:h-[400px]
+             -bottom-20 -left-20 pointer-events-none"
+      aria-hidden="true">
+    </div>
+
     <% if notice %>
-      <div data-controller="flash" data-action="click->flash#dismiss" class="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-xs cursor-pointer select-none">
+      <div
+        data-controller="flash"
+        data-action="click->flash#dismiss"
+        class="fixed top-4 left-1/2 -translate-x-1/2 z-50
+               w-[calc(100%-2rem)] max-w-sm
+               cursor-pointer select-none">
         <div class="alert alert-soft alert-success shadow-lg rounded-2xl">
           <span class="material-symbols-outlined">check_circle</span>
           <span class="text-sm font-bold"><%= notice %></span>
@@ -25,16 +46,24 @@
     <% end %>
 
     <% if alert %>
-      <% unless (controller_name == 'sessions' && action_name == 'new') %>
-        <div data-controller="flash" 
-             data-flash-auto-dismiss-value="false"
-            data-action="click->flash#dismiss" 
-            class="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-full max-w-xs cursor-pointer select-none alert alert-soft alert-error shadow-lg rounded-2xl flex items-center gap-2">
+      <% unless controller_name == "sessions" && action_name == "new" %>
+        <div
+          data-controller="flash"
+          data-flash-auto-dismiss-value="false"
+          data-action="click->flash#dismiss"
+          class="fixed top-4 left-1/2 -translate-x-1/2 z-50
+                 w-[calc(100%-2rem)] max-w-sm
+                 cursor-pointer select-none
+                 alert alert-soft alert-error shadow-lg rounded-2xl
+                 flex items-center gap-2">
           <span class="material-symbols-outlined">error</span>
           <span class="text-sm font-medium"><%= alert %></span>
         </div>
       <% end %>
     <% end %>
-    <%= yield %>
+
+    <div class="relative z-10">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/watchlists/_watchlist_card.html.erb
+++ b/app/views/watchlists/_watchlist_card.html.erb
@@ -1,64 +1,138 @@
-<%= link_to watchlist_path(watchlist), class: "block transition-transform duration-200 active:scale-[0.98]" do %>
-  <div class="relative group bg-white rounded-xl p-5 sticky-note-shadow flex items-center justify-between border-l-8 <%= is_past ? 'border-gray-300' : 'border-[#B6E0F3]' %>">
-    <div class="flex-1 pr-4 <%= 'opacity-60' if is_past || watchlist.is_done? %>">
-      <p class="font-label text-xs text-on-surface-variant/70 mb-2">
-        <%= watchlist.start_at&.strftime("%Y.%m.%d %H:%M") %>
-        
-         <% if watchlist.reception_detail.present? %>
-          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
-            <%= watchlist.reception_detail %>
-          </span>
-        <% end %>
-        
-        <% if watchlist.reception_type != "not_set" %>
-          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
-            <%= watchlist.reception_type_label %>
-          </span>
-        <% end %>
+<%= link_to watchlist_path(watchlist),
+            class: "block rounded-xl transition-transform duration-200
+                    active:scale-[0.98]
+                    focus-visible:outline
+                    focus-visible:outline-2
+                    focus-visible:outline-offset-2
+                    focus-visible:outline-[#2d6489]" do %>
 
-      </p>
-      <h3 class="font-headline font-bold text-lg text-on-surface leading-tight line-clamp-2 break-all">
-        <%= watchlist.title %>
-      </h3>
+  <article class="relative group
+                  min-h-28
+                  bg-white rounded-xl
+                  px-4 py-4 sm:p-5
+                  sticky-note-shadow
+                  border-l-6 sm:border-l-8
+                  <%= is_past ? 'border-gray-300' : 'border-[#B6E0F3]' %>">
+
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <%# 左側：日時・種別・タイトル %>
+      <div class="min-w-0 flex-1 pr-8 <%= 'opacity-60' if is_past || watchlist.is_done? %>">
+        <div class="flex flex-wrap items-center gap-1.5 mb-2">
+          <% if watchlist.start_at.present? %>
+            <time class="font-label text-xs text-on-surface-variant/70">
+              <%= watchlist.start_at.strftime("%Y.%m.%d %H:%M") %>
+            </time>
+          <% end %>
+
+          <% if watchlist.reception_detail.present? %>
+            <span class="inline-flex items-center
+                         min-h-6
+                         bg-[#B6E0F3]/50 text-[#2d6489]
+                         text-[10px] font-bold
+                         px-2.5 py-1
+                         rounded-full
+                         leading-none">
+              <%= watchlist.reception_detail %>
+            </span>
+          <% end %>
+
+          <% if watchlist.reception_type != "not_set" %>
+            <span class="inline-flex items-center
+                         min-h-6
+                         bg-[#B6E0F3]/50 text-[#2d6489]
+                         text-[10px] font-bold
+                         px-2.5 py-1
+                         rounded-full
+                         leading-none">
+              <%= watchlist.reception_type_label %>
+            </span>
+          <% end %>
+        </div>
+
+        <h3 class="font-headline font-bold
+                   text-base sm:text-lg
+                   text-on-surface
+                   leading-snug
+                   line-clamp-2
+                   break-words">
+          <%= watchlist.title %>
+        </h3>
+      </div>
+
+      <%# 右側：ステータス %>
+      <div class="flex items-center justify-between gap-3
+                  sm:flex-col sm:items-end sm:justify-center
+                  sm:min-h-12
+                  <%= 'opacity-60' if is_past || watchlist.is_done? %>">
+
+        <div>
+          <% if watchlist.is_done? %>
+            <span class="inline-flex items-center min-h-7
+                         text-[10px] font-bold
+                         px-3 py-1
+                         text-gray-400 italic">
+              対応済み
+            </span>
+
+          <% elsif !is_past %>
+            <% if watchlist.start_at.present? && watchlist.start_at > Time.current %>
+              <% days_to_start = (watchlist.start_at.to_date - Date.current).to_i %>
+
+              <span class="inline-flex items-center min-h-7
+                           bg-[#B6E0F3]/50 text-[#2d6489]
+                           text-[10px] font-bold
+                           px-3 py-1
+                           rounded-full
+                           leading-none
+                           whitespace-nowrap">
+                <%= days_to_start <= 0 ? "本日開始！" : "開始まであと#{days_to_start}日" %>
+              </span>
+
+            <% elsif watchlist.end_at.present? && watchlist.end_at >= Time.current %>
+              <% days_left = (watchlist.end_at.to_date - Date.current).to_i %>
+
+              <span class="inline-flex items-center min-h-7
+                           bg-[#B6E0F3]/50 text-[#2d6489]
+                           text-[10px] font-bold
+                           px-3 py-1
+                           rounded-full
+                           leading-none
+                           whitespace-nowrap">
+                <%= days_left <= 0 ? "締切当日！" : "締切まであと#{days_left}日" %>
+              </span>
+            <% end %>
+
+          <% elsif watchlist.end_at.present? && watchlist.end_at < Time.current %>
+            <span class="inline-flex items-center min-h-7
+                         text-[10px] font-bold
+                         px-3 py-1
+                         text-gray-400 italic">
+              受付終了
+            </span>
+
+          <% elsif is_past %>
+            <span class="inline-flex items-center min-h-7
+                         text-[10px] font-bold
+                         px-3 py-1
+                         text-gray-400 italic">
+              思い出
+            </span>
+          <% end %>
+        </div>
+
+        <% if is_past ||
+              watchlist.is_done? ||
+              (watchlist.end_at.present? && watchlist.end_at < Time.current) %>
+          <span class="material-symbols-outlined text-gray-300" aria-hidden="true">
+            inventory_2
+          </span>
+        <% else %>
+          <span class="material-symbols-outlined absolute top-4 right-4 text-lg text-[#B6E0F3]"
+                        aria-hidden="true">
+            push_pin
+          </span>
+        <% end %>
+      </div>
     </div>
-    
-    <div class="flex flex-col items-end justify-center min-h-[48px] gap-2 <%= 'opacity-60' if is_past || watchlist.is_done? %>">
-      <% if watchlist.is_done? %>
-        <%# 1. 対応済みの場合 %>
-        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic mb-1">対応済み</span>
-
-      <% elsif !is_past %>
-        <%# 2. これからの予定（開始前、または締切前） %>
-        <% if watchlist.start_at.present? && watchlist.start_at > Time.current %>
-          <% days_to_start = (watchlist.start_at.to_date - Date.today).to_i %>
-          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
-            <%= days_to_start <= 0 ? "本日開始！" : "開始まであと#{days_to_start}日" %>
-          </span>
-        <% elsif watchlist.end_at.present? && watchlist.end_at >= Time.current %>
-          <% days_left = (watchlist.end_at.to_date - Date.today).to_i %>
-          <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-[10px] font-bold px-3 py-1 rounded-full uppercase tracking-wider">
-            <%= days_left <= 0 ? "締切当日！" : "締切まであと#{days_left}日" %>
-          </span>
-        <% end %>
-
-      <% elsif watchlist.end_at.present? && watchlist.end_at < Time.current %>
-        <%# 3. 未完了のまま期限が過ぎた場合（受付終了） %>
-        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic mb-1">受付終了</span>
-      <% elsif is_past %>
-        <%# 4. それ以外の過去の予定（思い出） %>
-        <span class="text-[10px] font-bold px-3 py-1 text-gray-400 italic mb-1">思い出</span>
-      <% end %>
-
-      <%# 📌 アイコンの出し分けと位置調整を完全に分離 %>
-      <% if is_past || watchlist.is_done? || (watchlist.end_at.present? && watchlist.end_at < Time.current) %>
-        <%# 【過去・完了・受付終了】は一括して「箱アイコン」をバッジの下に表示 %>
-        <span class="material-symbols-outlined text-gray-300">inventory_2</span>
-      <% else %>
-        <%# 【現在・未来の未完了タスク】のみ、右上ピンを配置 %>
-        <span class="material-symbols-outlined absolute top-4 right-4 text-xs text-[#B6E0F3]">
-          push_pin
-        </span>
-      <% end %>
-    </div>
-  </div>
+  </article>
 <% end %>

--- a/app/views/watchlists/index.html.erb
+++ b/app/views/watchlists/index.html.erb
@@ -1,46 +1,79 @@
-<main class="max-w-screen-xl mx-auto px-6 mt-16 pb-40">
-  <!-- これからの予定セクション -->
-  <!-- Date Header Section -->
-  <div class="mb-12 pt-4 text-center"> 
-    <h2 class="font-headline font-extrabold text-3xl tracking-tight text-primary">これからの予定</h2>
+<main class="w-full max-w-3xl mx-auto px-4 sm:px-6 mt-10 md:mt-14 pb-40 md:pb-32">
+  <%# これからの予定セクション %>
+  <div class="mb-8 md:mb-10 pt-4 text-center">
+    <h2 class="font-headline font-extrabold text-2xl sm:text-3xl tracking-tight text-primary">
+      これからの予定
+    </h2>
   </div>
+
   <div class="mb-6">
     <% if @future_watchlists.any? %>
-      <div class="space-y-6">
+      <div class="space-y-4 md:space-y-5">
         <% @future_watchlists.each do |watchlist| %>
-          <%= render 'watchlist_card', watchlist: watchlist, is_past: false %>
+          <%= render "watchlist_card", watchlist: watchlist, is_past: false %>
         <% end %>
       </div>
     <% else %>
-      <%# 未来の予定がない時のメッセージ %>
-      <div class="flex flex-col items-center justify-center py-12 text-center bg-white/30 rounded-3xl border border-dashed border-[#4f5052]">
-        <span class="material-symbols-outlined text-4xl text-[#B6E0F3] mb-2">auto_awesome</span>
-        <p class="text-[#4f5052] font-headline font-bold">お気に入りの予定を、ポケットに入れて持ち歩こう。</p>
+      <div class="flex flex-col items-center justify-center
+                  px-5 py-10 md:py-12
+                  text-center bg-white/30 rounded-3xl
+                  border border-dashed border-[#4f5052]">
+        <span class="material-symbols-outlined text-4xl text-[#B6E0F3] mb-2">
+          auto_awesome
+        </span>
+
+        <p class="text-[#4f5052] text-sm sm:text-base font-headline font-bold leading-relaxed">
+          お気に入りの予定を、ポケットに入れて持ち歩こう。
+        </p>
       </div>
     <% end %>
   </div>
 
-  <!-- 終わった予定（思い出）セクション -->
+  <%# 終わった予定セクション %>
   <% if @past_watchlists.any? %>
-    <div class="mt-12 mb-6 px-2 ">
-    <div class="divider font-headline text-sm opacity-40 gap-1">
-      <span>これまでの足跡</span>
-      <span class="material-symbols-outlined text-lg" style="font-variation-settings: 'opsz' 20, 'wght' 300;">
-        footprint
-      </span>
-    </div>
+    <section class="mt-10 md:mt-12 mb-6">
+      <div class="divider font-headline text-sm opacity-40 gap-1">
+        <span>これまでの足跡</span>
+
+        <span
+          class="material-symbols-outlined text-lg"
+          style="font-variation-settings: 'opsz' 20, 'wght' 300;">
+          footprint
+        </span>
+      </div>
+
+      <div class="space-y-4 md:space-y-5">
         <% @past_watchlists.each do |watchlist| %>
-          <div class="space-y-6">
-          <%= render 'watchlist_card', watchlist: watchlist, is_past: true %>
+          <%= render "watchlist_card", watchlist: watchlist, is_past: true %>
         <% end %>
       </div>
-    </div>
+    </section>
   <% end %>
 </main>
 
-<!-- Floating Action Button (新規作成へ) -->
-<%= link_to new_watchlist_path, class: "fixed bottom-24 right-6 z-50 w-14 h-14 rounded-2xl text-on-primary flex items-center justify-center transition-all duration-200 active:scale-90 shadow-2xl", style: "background-color: #B6E0F3;" do %>
-  <span class="material-symbols-outlined text-3xl text-[#2d6489]">add</span>
-<% end %>
+<%# 新規作成ボタン %>
+<div class="fixed inset-x-0 bottom-24 md:bottom-8 z-40 pointer-events-none">
+  <div class="w-full max-w-3xl mx-auto px-4 sm:px-6 flex justify-end">
+    <%= link_to new_watchlist_path,
+                class: "pointer-events-auto
+                        flex items-center justify-center
+                        w-14 h-14 md:w-12 md:h-12
+                        rounded-2xl
+                        text-on-primary
+                        transition-all duration-200
+                        active:scale-90 hover:scale-105
+                        shadow-2xl
+                        focus-visible:outline
+                        focus-visible:outline-2
+                        focus-visible:outline-offset-2
+                        focus-visible:outline-[#2d6489]",
+                style: "background-color: #B6E0F3;",
+                aria: { label: "予定を新しく登録する" } do %>
+      <span class="material-symbols-outlined text-3xl md:text-2xl text-[#2d6489]">
+        add
+      </span>
+    <% end %>
+  </div>
+</div>
 
-<%= render 'layouts/footer' %>
+<%= render "layouts/footer" %>


### PR DESCRIPTION
## 概要
モバイルファーストを意識し、一覧画面と共通レイアウトのレスポンシブUIを改善しました。

スマートフォンではタップしやすさと情報の見やすさを整え、PCではコンテンツ幅を制限して視線移動を抑えています。

## 背景
スマートフォンからの利用をメインに想定しているため、片手操作でも誤タップしにくく、快適に操作できるUIにする必要がありました。

また、PC表示ではコンテンツが横に広がりすぎていたため、画面幅が広い場合でも一覧情報を見やすくするために対応しました。

Closes #78

## 変更内容
- 共通レイアウトの背景装飾を `body` 内へ移動
- 横スクロールが発生しにくいよう、共通レイアウトに `overflow-x-hidden` を追加
- フラッシュメッセージの幅をスマートフォンでも左右に余白が残るよう調整
- 一覧画面の最大幅を `max-w-3xl` に制限し、PC表示で中央寄せ
- スマートフォンとPCで余白やカード間隔が変わるようレスポンシブ対応
- 新規作成ボタンの位置とサイズを画面幅に応じて調整
- 下部ナビゲーションのリンク全体に十分なタップ領域を確保
- 一覧カードをスマートフォンでは縦並び、広い画面では横並びになるよう調整
- 日時・受付種別バッジが自然に折り返されるよう修正
- タイトルの折り返しを `break-all` から `break-words` に変更
- 日付計算を `Date.today` から `Date.current` に変更
- ピンアイコンをカード右上に固定
- 終了済み・対応済みの予定は `opacity-60` で表示し、これからの予定と区別
- 過去予定一覧のHTML構造とカード間隔を整理

## 確認方法
- 一覧画面を開く
- 開発者ツールのデバイスツールバーを有効にする
- 344px、375px、390px前後のスマートフォン幅で表示崩れがないことを確認
- 日時、受付種別、タイトル、ステータスがカード内に収まることを確認
- カード、下部ナビゲーション、新規作成ボタンをタップできることを確認
- 768px前後でレスポンシブ表示が自然に切り替わることを確認
- PC幅でコンテンツが中央寄せされ、横に広がりすぎないことを確認
- これからの予定と終了済みの予定が見た目で区別できることを確認
- `docker compose exec web bundle exec rubocop` を実行し、違反がないことを確認

## 影響範囲
- 共通レイアウト
- フラッシュメッセージ
- 予定一覧画面
- 予定カード
- 下部ナビゲーション
- 新規作成ボタン

データの登録・更新・削除処理や通知機能への影響はありません。

## スクリーンショット
### スマートフォン表示
<img width="813" height="992" alt="image" src="https://github.com/user-attachments/assets/d29b58fd-90a9-42b5-92a2-cb6643ba3bde" />


### PC表示
<img width="1919" height="990" alt="image" src="https://github.com/user-attachments/assets/4603ea36-f0ed-4697-9bb3-9d3631915671" />

## 補足
スマートフォン用とPC用でViewファイルは分けず、Tailwind CSSのレスポンシブユーティリティを使用して単一のView内で調整しました。

終了済み・対応済みの予定については、これから対応する予定との違いを判断しやすくするため、日時・タイトル・ステータスを含む表示を `opacity-60` のままとしています。