### PR TITLE
共通レイアウト（ヘッダー・PC用サイドバー）の実装

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,3 +7,6 @@ import { application } from "controllers/application"
 // Importmap環境でコントローラーを正しく自動ロードする記述
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 eagerLoadControllersFrom("controllers", application)
+
+import SidebarController from "./sidebar_controller"
+application.register("sidebar", SidebarController)

--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["panel", "overlay"]
+
+  open() {
+    this.panelTarget.classList.remove("-translate-x-full")
+    this.panelTarget.classList.add("translate-x-0")
+    this.overlayTarget.classList.remove("hidden")
+  }
+
+  close() {
+    this.panelTarget.classList.remove("translate-x-0")
+    this.panelTarget.classList.add("-translate-x-full")
+    this.overlayTarget.classList.add("hidden")
+  }
+}

--- a/app/views/layouts/_app_navigation.html.erb
+++ b/app/views/layouts/_app_navigation.html.erb
@@ -1,0 +1,6 @@
+<div data-controller="sidebar">
+  <%= render "layouts/header",
+             back_path: local_assigns[:back_path] %>
+
+  <%= render "layouts/sidebar" %>
+</div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,6 +1,7 @@
 <nav
   class="fixed bottom-0 left-0 z-50
          w-full
+         md:hidden
          bg-white
          rounded-t-3xl
          shadow-[0_-4px_20px_rgba(0,0,0,0.1)]

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,6 @@
 <header class="bg-white/80 backdrop-blur-sm sticky top-0 z-40
                transition-colors border-b border-white shadow-sm">
-  <div class="relative flex items-center justify-center w-full px-4 py-5 ">
+  <div class="relative flex items-center justify-center w-full px-4 py-5">
     <div class="absolute left-4 flex items-center">
       <% if local_assigns[:back_path].present? %>
         <%= link_to back_path,
@@ -15,9 +15,11 @@
 
       <button
         type="button"
+        data-action="click->sidebar#open"
         class="hidden md:flex items-center justify-center
                text-primary hover:opacity-70 transition-opacity"
-        aria-label="メニューを開く">
+        aria-label="メニューを開く"
+        aria-expanded="false">
         <span class="material-symbols-outlined">
           menu
         </span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,39 @@
+<header class="bg-white/80 backdrop-blur-sm sticky top-0 z-40
+               transition-colors border-b border-white shadow-sm">
+  <div class="relative flex items-center justify-center w-full px-4 py-5 ">
+    <div class="absolute left-4 flex items-center">
+      <% if local_assigns[:back_path].present? %>
+        <%= link_to back_path,
+                    class: "md:hidden flex items-center justify-center
+                            text-primary hover:opacity-70 transition-opacity",
+                    aria: { label: "前の画面に戻る" } do %>
+          <span class="material-symbols-outlined">
+            arrow_back
+          </span>
+        <% end %>
+      <% end %>
+
+      <button
+        type="button"
+        class="hidden md:flex items-center justify-center
+               text-primary hover:opacity-70 transition-opacity"
+        aria-label="メニューを開く">
+        <span class="material-symbols-outlined">
+          menu
+        </span>
+      </button>
+    </div>
+
+    <div class="flex items-center gap-2 bg-white/50 px-3 py-1.5 rounded-full border border-white shadow-sm">
+      <%= image_tag "logo.png",
+          class: "w-8 h-8 md:w-9 md:h-9 object-contain",
+          alt: "" %>
+
+      <span class="font-headline font-bold text-xl md:text-2xl tracking-tight text-primary">
+        FanPocket
+      </span>
+    </div>
+
+    <div class="absolute right-4 w-6" aria-hidden="true"></div>
+  </div>
+</header>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,10 +1,22 @@
+<div
+  data-sidebar-target="overlay"
+  data-action="click->sidebar#close"
+  class="fixed inset-0 z-40
+         hidden
+         bg-black/20"
+  aria-hidden="true">
+</div>
+
 <aside
+  data-sidebar-target="panel"
   class="fixed top-0 left-0 z-50
          hidden md:block
          w-72 h-full
          bg-white/95 backdrop-blur-sm
          border-r border-white
-         shadow-xl">
+         shadow-xl
+         -translate-x-full
+         transition-transform duration-300">
 
   <div class="flex items-center justify-between px-5 py-5 border-b border-slate-100">
     <span class="font-headline font-bold text-xl text-primary">
@@ -13,6 +25,7 @@
 
     <button
       type="button"
+      data-action="click->sidebar#close"
       class="flex items-center justify-center
              text-primary hover:opacity-70
              transition-opacity"

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -1,0 +1,61 @@
+<aside
+  class="fixed top-0 left-0 z-50
+         hidden md:block
+         w-72 h-full
+         bg-white/95 backdrop-blur-sm
+         border-r border-white
+         shadow-xl">
+
+  <div class="flex items-center justify-between px-5 py-5 border-b border-slate-100">
+    <span class="font-headline font-bold text-xl text-primary">
+      メニュー
+    </span>
+
+    <button
+      type="button"
+      class="flex items-center justify-center
+             text-primary hover:opacity-70
+             transition-opacity"
+      aria-label="メニューを閉じる">
+      <span class="material-symbols-outlined">
+        close
+      </span>
+    </button>
+  </div>
+
+  <nav class="p-4" aria-label="PC用メインナビゲーション">
+    <div class="space-y-2">
+      <%= link_to watchlists_path,
+                  class: "flex items-center gap-3
+                          px-4 py-3
+                          rounded-2xl
+                          text-primary
+                          hover:bg-[#B6E0F3]/30
+                          transition-colors" do %>
+        <span class="material-symbols-outlined">
+          lists
+        </span>
+
+        <span class="font-bold">
+          これからの予定
+        </span>
+      <% end %>
+
+      <%= link_to settings_path,
+                  class: "flex items-center gap-3
+                          px-4 py-3
+                          rounded-2xl
+                          text-primary
+                          hover:bg-[#B6E0F3]/30
+                          transition-colors" do %>
+        <span class="material-symbols-outlined">
+          settings
+        </span>
+
+        <span class="font-bold">
+          設定
+        </span>
+      <% end %>
+    </div>
+  </nav>
+</aside>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,6 +1,6 @@
 <%= render "layouts/header",
            back_path: watchlists_path %>
-
+<%= render "layouts/sidebar" %>
 
 <main class="px-6 mt-6 space-y-6 max-w-2xl mx-auto pb-28">
   <div class="mb-4">

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,19 +1,6 @@
-<header class="bg-white/80 backdrop-blur-sm sticky top-0 z-40 transition-colors border-b border-white">
-  <div class="max-w-full mx-auto px-4 py-3">
-    <div class="flex items-center justify-between w-full">
-      <div class="flex items-center gap-3">
-        <%= link_to root_path, class: "material-symbols-outlined text-primary hover:opacity-70 transition-opacity" do %>
-          arrow_back
-        <% end %>
-        <h1 class="font-headline font-bold text-lg text-primary">これからの予定</h1>
-      </div>
-      <div class="flex items-center gap-2 bg-white/50 px-3 py-1.5 rounded-full border border-white shadow-sm">
-        <%= image_tag "logo.png", class: "w-6 h-6 object-contain", alt: "FanPocket Logo" %>
-        <span class="font-headline font-bold tracking-tight text-primary">FanPocket</span>
-      </div>
-    </div>
-  </div>
-</header>
+<%= render "layouts/header",
+           back_path: watchlists_path %>
+
 
 <main class="px-6 mt-6 space-y-6 max-w-2xl mx-auto pb-28">
   <div class="mb-4">

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,11 +1,14 @@
-<%= render "layouts/header",
-           back_path: watchlists_path %>
-<%= render "layouts/sidebar" %>
+<%= render "layouts/app_navigation" %>
 
-<main class="px-6 mt-6 space-y-6 max-w-2xl mx-auto pb-28">
-  <div class="mb-4">
-    <h2 class="font-headline font-extrabold text-2xl text-center text-primary">設定</h2>
-    <p class="text-center text-[#4f5052] text-sm mt-1">アプリの使い心地を調整しましょう</p>
+<main class="w-full max-w-2xl mx-auto px-4 sm:px-6 mt-10 md:mt-14 pb-28 md:pb-12">
+  <div class="mb-8 md:mb-10 text-center">
+    <h2 class="font-headline font-extrabold text-4xl tracking-tight text-primary">
+      設定
+    </h2>
+
+    <p class="mt-2 text-center text-[#4f5052] text-base">
+      アプリの使い心地を調整しましょう
+    </p>
   </div>
 
   <section>

--- a/app/views/watchlists/edit.html.erb
+++ b/app/views/watchlists/edit.html.erb
@@ -1,6 +1,5 @@
-<%= render "layouts/header",
+<%= render "layouts/app_navigation",
            back_path: watchlist_path %>
-<%= render "layouts/sidebar" %>
 
 <div class="hidden md:block w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4">
   <%= link_to watchlist_path(@watchlist),
@@ -16,8 +15,8 @@
 
 <main class="flex-grow px-6 max-w-3xl mx-auto w-full pt-8">
   <div class="mb-10">
-    <h2 class="font-headline font-extrabold text-4xl text-center text-primary tracking-tight">予定の編集</h2>
-    <p class="text-center text-[#4f5052] text-base mt-2">登録内容を修正して更新しましょう</p>
+    <h2 class="font-headline font-extrabold text-3xl text-center text-primary tracking-tight">予定の編集</h2>
+    <p class="text-center text-[#4f5052] text-sm mt-2">登録内容を修正して更新しましょう</p>
   </div>
 
   <%= render 'form', watchlist: @watchlist %>

--- a/app/views/watchlists/edit.html.erb
+++ b/app/views/watchlists/edit.html.erb
@@ -1,10 +1,23 @@
 <%= render "layouts/header",
            back_path: watchlist_path %>
+<%= render "layouts/sidebar" %>
+
+<div class="hidden md:block w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4">
+  <%= link_to watchlist_path(@watchlist),
+              class: "inline-flex items-center gap-1
+                      text-base font-bold text-primary
+                      hover:opacity-70 transition-opacity" do %>
+    <span class="material-symbols-outlined text-xl">
+      arrow_back
+    </span>
+    <span>予定の詳細へ</span>
+  <% end %>
+</div>
 
 <main class="flex-grow px-6 max-w-3xl mx-auto w-full pt-8">
   <div class="mb-10">
-    <h2 class="font-headline font-extrabold text-3xl text-center text-primary tracking-tight">予定の編集</h2>
-    <p class="text-center text-[#4f5052] text-sm mt-2">登録内容を修正して更新しましょう</p>
+    <h2 class="font-headline font-extrabold text-4xl text-center text-primary tracking-tight">予定の編集</h2>
+    <p class="text-center text-[#4f5052] text-base mt-2">登録内容を修正して更新しましょう</p>
   </div>
 
   <%= render 'form', watchlist: @watchlist %>

--- a/app/views/watchlists/edit.html.erb
+++ b/app/views/watchlists/edit.html.erb
@@ -1,19 +1,5 @@
-<header class="bg-white/80 backdrop-blur-sm sticky top-0 z-40 transition-colors border-b border-white">
-  <div class="max-w-full mx-auto px-4 py-3">
-    <div class="flex items-center justify-between w-full">
-      <div class="flex items-center gap-3">
-        <%= link_to watchlist_path, class: "material-symbols-outlined text-primary hover:opacity-70 transition-opacity" do %>
-          arrow_back
-        <% end %>
-        <h1 class="font-headline font-bold text-lg text-primary">予定の詳細</h1>
-      </div>
-      <div class="flex items-center gap-2 bg-white/50 px-3 py-1.5 rounded-full border border-white shadow-sm">
-        <%= image_tag "logo.png", class: "w-6 h-6 object-contain", alt: "FanPocket Logo" %>
-        <span class="font-headline font-bold tracking-tight text-primary">FanPocket</span>
-      </div>
-    </div>
-  </div>
-</header>
+<%= render "layouts/header",
+           back_path: watchlist_path %>
 
 <main class="flex-grow px-6 max-w-3xl mx-auto w-full pt-8">
   <div class="mb-10">

--- a/app/views/watchlists/index.html.erb
+++ b/app/views/watchlists/index.html.erb
@@ -1,14 +1,13 @@
-<%= render "layouts/header" %>
-<%= render "layouts/sidebar" %>
+<%= render "layouts/app_navigation" %>
+
+<div class="text-center mt-15 mb-15">
+  <h2 class="font-headline font-extrabold text-3xl tracking-tight text-primary">
+    これからの予定
+  </h2>
+</div>
 
 <main class="w-full max-w-3xl mx-auto px-4 sm:px-6 mt-10 md:mt-14 pb-40 md:pb-32">
   <%# これからの予定セクション %>
-  <div class="mb-8 md:mb-10 pt-4 text-center">
-    <h2 class="font-headline font-extrabold text-2xl sm:text-3xl tracking-tight text-primary">
-      これからの予定
-    </h2>
-  </div>
-
   <div class="mb-6">
     <% if @future_watchlists.any? %>
       <div class="space-y-4 md:space-y-5">
@@ -55,8 +54,9 @@
 </main>
 
 <%# 新規作成ボタン %>
-<div class="fixed inset-x-0 bottom-24 md:bottom-8 z-40 pointer-events-none">
-  <div class="w-full max-w-3xl mx-auto px-4 sm:px-6 flex justify-end">
+<div class="fixed inset-x-0 bottom-24 md:inset-x-auto md:right-10 md:bottom-10 z-40 pointer-events-none">
+  <div class="w-full max-w-3xl mx-auto px-4 sm:px-6 flex justify-end
+              md:w-auto md:max-w-none md:px-0">
     <%= link_to new_watchlist_path,
                 class: "pointer-events-auto
                         flex items-center justify-center

--- a/app/views/watchlists/index.html.erb
+++ b/app/views/watchlists/index.html.erb
@@ -1,4 +1,5 @@
 <%= render "layouts/header" %>
+<%= render "layouts/sidebar" %>
 
 <main class="w-full max-w-3xl mx-auto px-4 sm:px-6 mt-10 md:mt-14 pb-40 md:pb-32">
   <%# これからの予定セクション %>

--- a/app/views/watchlists/index.html.erb
+++ b/app/views/watchlists/index.html.erb
@@ -1,3 +1,5 @@
+<%= render "layouts/header" %>
+
 <main class="w-full max-w-3xl mx-auto px-4 sm:px-6 mt-10 md:mt-14 pb-40 md:pb-32">
   <%# これからの予定セクション %>
   <div class="mb-8 md:mb-10 pt-4 text-center">

--- a/app/views/watchlists/new.html.erb
+++ b/app/views/watchlists/new.html.erb
@@ -2,11 +2,24 @@
   <!-- TopAppBar -->
   <%= render "layouts/header",
            back_path: watchlists_path %>
+  <%= render "layouts/sidebar" %>
+
+  <div class="hidden md:block w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4">
+    <%= link_to watchlists_path,
+                class: "inline-flex items-center gap-1
+                        text-base font-bold text-primary
+                        hover:opacity-70 transition-opacity" do %>
+      <span class="material-symbols-outlined text-xl">
+        arrow_back
+      </span>
+      <span>これからの予定へ</span>
+    <% end %>
+  </div>
 
   <main class="flex-grow px-6 max-w-3xl mx-auto w-full pt-8">
     <div class="mb-10">
-      <h2 class="font-headline font-extrabold text-3xl text-center text-primary tracking-tight">予定の追加</h2>
-      <p class="text-center text-[#4f5052] text-sm mt-2">URLを保存して新しい活動を記録しましょう</p>
+      <h2 class="font-headline font-extrabold text-4xl text-center text-primary tracking-tight">予定の追加</h2>
+      <p class="text-center text-[#4f5052] text-base mt-2">URLを保存して新しい活動を記録しましょう</p>
     </div>
 
     <%= render 'form', watchlist: @watchlist %>

--- a/app/views/watchlists/new.html.erb
+++ b/app/views/watchlists/new.html.erb
@@ -1,22 +1,8 @@
 <body class="bg-surface text-on-surface font-body min-h-screen pb-32">
   <!-- TopAppBar -->
-  <header class="bg-white/80 backdrop-blur-sm sticky top-0 z-40 transition-colors border-b border-white">
-  <div class="max-w-full mx-auto px-4 py-3">
-    <div class="flex items-center justify-between w-full">
-      <div class="flex items-center gap-3">
-        <%= link_to root_path, class: "material-symbols-outlined text-primary hover:opacity-70 transition-opacity" do %>
-          arrow_back
-        <% end %>
-        <h1 class="font-headline font-bold text-lg text-primary">これからの予定</h1>
-      </div>
-      <div class="flex items-center gap-2 bg-white/50 px-3 py-1.5 rounded-full border border-white shadow-sm">
-        <%= image_tag "logo.png", class: "w-6 h-6 object-contain", alt: "FanPocket Logo" %>
-        <span class="font-headline font-bold tracking-tight text-primary">FanPocket</span>
-      </div>
+  <%= render "layouts/header",
+           back_path: watchlists_path %>
 
-    </div>
-  </div>
-  </header>
   <main class="flex-grow px-6 max-w-3xl mx-auto w-full pt-8">
     <div class="mb-10">
       <h2 class="font-headline font-extrabold text-3xl text-center text-primary tracking-tight">予定の追加</h2>

--- a/app/views/watchlists/new.html.erb
+++ b/app/views/watchlists/new.html.erb
@@ -1,8 +1,7 @@
 <body class="bg-surface text-on-surface font-body min-h-screen pb-32">
   <!-- TopAppBar -->
-  <%= render "layouts/header",
+  <%= render "layouts/app_navigation",
            back_path: watchlists_path %>
-  <%= render "layouts/sidebar" %>
 
   <div class="hidden md:block w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4">
     <%= link_to watchlists_path,
@@ -16,12 +15,16 @@
     <% end %>
   </div>
 
-  <main class="flex-grow px-6 max-w-3xl mx-auto w-full pt-8">
-    <div class="mb-10">
-      <h2 class="font-headline font-extrabold text-4xl text-center text-primary tracking-tight">予定の追加</h2>
-      <p class="text-center text-[#4f5052] text-base mt-2">URLを保存して新しい活動を記録しましょう</p>
-    </div>
+  <div class="text-center mt-10 mb-10">
+    <h2 class="font-headline font-extrabold text-3xl tracking-tight text-primary">
+      予定の追加
+    </h2>
+    <p class="text-center text-[#4f5052] text-sm mt-2">
+      URLを保存して新しい活動を記録しましょう
+    </p>
+  </div>
 
+  <main class="flex-grow px-6 max-w-3xl mx-auto w-full pt-8">
     <%= render 'form', watchlist: @watchlist %>
   </main>
 </body>

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -1,5 +1,18 @@
 <%= render "layouts/header",
            back_path: watchlists_path %>
+<%= render "layouts/sidebar" %>
+
+<div class="hidden md:block w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4">
+  <%= link_to watchlists_path,
+              class: "inline-flex items-center gap-1
+                      text-sm font-bold text-primary
+                      hover:opacity-70 transition-opacity" do %>
+    <span class="material-symbols-outlined text-xl">
+      arrow_back
+    </span>
+    <span>これからの予定へ</span>
+  <% end %>
+</div>
 
 <main class="max-w-2xl mx-auto px-6 mt-4 space-y-8">
   <!-- Page Header -->

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -1,24 +1,10 @@
-<header class="bg-white/80 backdrop-blur-sm sticky top-0 z-40 transition-colors border-b border-white">
-  <div class="max-w-full mx-auto px-4 py-3">
-    <div class="flex items-center justify-between w-full">
-      <div class="flex items-center gap-3">
-        <%= link_to root_path, class: "material-symbols-outlined text-primary hover:opacity-70 transition-opacity" do %>
-          arrow_back
-        <% end %>
-        <h1 class="font-headline font-bold text-lg text-primary">これからの予定</h1>
-      </div>
-      <div class="flex items-center gap-2 bg-white/50 px-3 py-1.5 rounded-full border border-white shadow-sm">
-        <%= image_tag "logo.png", class: "w-6 h-6 object-contain", alt: "FanPocket Logo" %>
-        <span class="font-headline font-bold tracking-tight text-primary">FanPocket</span>
-      </div>
-    </div>
-  </div>
-</header>
+<%= render "layouts/header",
+           back_path: watchlists_path %>
 
 <main class="max-w-2xl mx-auto px-6 mt-4 space-y-8">
   <!-- Page Header -->
   <div class="mb-10">
-    <h2 class="font-headline font-extrabold text-3xl text-center text-primary tracking-tight">予定の詳細</h2>
+    <h2 class="font-headline font-extrabold mt-13 text-4xl text-center text-primary tracking-tight">予定の詳細</h2>
   </div>
 
   <!-- Title Section -->

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -1,6 +1,5 @@
-<%= render "layouts/header",
+<%= render "layouts/app_navigation",
            back_path: watchlists_path %>
-<%= render "layouts/sidebar" %>
 
 <div class="hidden md:block w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4">
   <%= link_to watchlists_path,
@@ -16,8 +15,8 @@
 
 <main class="max-w-2xl mx-auto px-6 mt-4 space-y-8">
   <!-- Page Header -->
-  <div class="mb-10">
-    <h2 class="font-headline font-extrabold mt-13 text-4xl text-center text-primary tracking-tight">予定の詳細</h2>
+  <div class="mb-15">
+    <h2 class="font-headline font-extrabold mt-13 mb-4 text-3xl text-center text-primary tracking-tight">予定の詳細</h2>
   </div>
 
   <!-- Title Section -->


### PR DESCRIPTION
## 概要
一覧・詳細・新規登録・編集・設定画面に共通ヘッダーを適用し、PC表示向けのサイドバーを実装しました。

## 背景
PC表示でも主要画面へ移動しやすくし、画面ごとに重複していたヘッダーを共通化するためです。

Close #118

## 変更内容
- 共通ヘッダーをパーシャル化
- ヘッダー中央にロゴと「FanPocket」を表示
- PC表示時にメニューアイコンを表示
- StimulusでPC用サイドバーの開閉機能を実装
- オーバーレイおよび閉じるボタンを追加
- サイドバーに「これからの予定」「設定」へのリンクを追加
- スマートフォンでは戻る矢印、PCでは画面内の戻るリンクを表示
- PC表示では下部ナビゲーションを非表示
- PC表示時の新規登録ボタンの位置を調整
- 各画面のページタイトルの見た目を統一
- 設定画面の余白とタイトル表示を調整

## 確認方法
- 一覧・詳細・新規登録・編集・設定画面で共通ヘッダーが表示されること
- スマートフォン表示で戻る矢印と下部ナビゲーションが表示されること
- PC表示でメニューアイコンが表示され、下部ナビゲーションが非表示になること
- メニューアイコンを押すとサイドバーが左側から表示されること
- 閉じるボタンまたはオーバーレイを押すとサイドバーが閉じること
- サイドバーから「これからの予定」「設定」へ移動できること
- 詳細・新規登録・編集画面のPC用戻るリンクが適切な画面へ遷移すること
- スマートフォン・PCの両方でレイアウトが崩れないこと

## 影響範囲
- 一覧画面
- 詳細画面
- 新規登録画面
- 編集画面
- 設定画面
- 共通ヘッダー
- PC用サイドバー
- スマートフォン用下部ナビゲーション

## スクリーンショット
- PC表示の共通ヘッダー
<img width="1919" height="988" alt="image" src="https://github.com/user-attachments/assets/91b3a612-dd78-4a31-88c5-775923445724" />

- サイドバーを開いた状態
<img width="1918" height="990" alt="image" src="https://github.com/user-attachments/assets/24986586-0ab5-4bb2-80ac-c09c98044638" />

- スマートフォン表示
<img width="887" height="1012" alt="image" src="https://github.com/user-attachments/assets/3da78a08-1cbf-47cb-a11f-c5cbb2a3b08f" />

## 補足
PCではサイドバーをグローバルナビゲーションとして使用し、詳細・新規登録・編集画面では親画面へ戻れるリンクを別途配置しました。

一覧画面とスマートフォン用下部ナビゲーションで使用している文言に合わせ、サイドバーのリンク名も「これからの予定」に統一しています。