### PR TITLE
共通レイアウト適用による既存機能の不具合修正

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,3 @@ import { application } from "controllers/application"
 // Importmap環境でコントローラーを正しく自動ロードする記述
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 eagerLoadControllersFrom("controllers", application)
-
-import SidebarController from "./sidebar_controller"
-application.register("sidebar", SidebarController)


### PR DESCRIPTION
## 概要
共通レイアウト適用後に発生していたStimulusコントローラーの読み込み不具合を修正し、フラッシュメッセージ・タイトル自動取得・Flatpickr・サイドバーの動作を復旧しました。

## 背景
closes #124

共通レイアウト導入後、一部のStimulusを利用した機能が正常に動作しなくなっていたため、原因を調査・修正しました。

## 変更内容
- `controllers/index.js`で重複していた`sidebar_controller`の手動登録を削除
- `eagerLoadControllersFrom`によるStimulusコントローラーの自動登録へ統一
- 本番環境で発生していた`sidebar_controller`の404エラーを解消
- フラッシュメッセージ、タイトル自動取得、Flatpickr、サイドバーが正常に動作することを確認

## 確認方法
- ログイン後、フラッシュメッセージが自動で消えること
- 新規登録画面でタイトル自動取得が正常に動作すること
- 日時入力でFlatpickrが正常に動作すること
- サイドバーが正常に表示・動作すること
- ブラウザのConsoleで404エラーが発生しないこと

## 影響範囲
### 影響がある画面/機能
- 共通レイアウトを利用する画面
- フラッシュメッセージ
- Watchlist新規登録（タイトル自動取得・日時入力）
- サイドバー

### 影響がないこと
- WatchlistのCRUD処理
- 設定画面など、Stimulusを利用しない既存機能

## 補足
今回の不具合は各機能固有の問題ではなく、Stimulusコントローラーの読み込み構成に起因していました。
個別修正ではなく、コントローラー登録方法を整理することで関連する不具合をまとめて解消しました。