### PR TITLE
Deviseルーティングの標準構成への見直し

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: ENV.fetch("MAILER_SENDER")
   layout 'mailer'
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV.fetch("MAILER_SENDER")
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :user, controllers: {
+  devise_for :users, controllers: {
     sessions: 'users/sessions',
     omniauth_callbacks: "users/omniauth_callbacks"
   }


### PR DESCRIPTION
## 概要
Deviseルーティングを標準構成（`devise_for :users`）へ変更しました。
あわせて、パスワードリセットメールの送信元設定を環境変数へ統一しました。

## 背景
現在、`devise_for :user` を使用しており、認証関連のURLが `/user/...` となっていました。
Deviseの標準構成に合わせることで保守性を向上させるため変更しました。

closes: #128

## 変更内容
- `devise_for :user` を `devise_for :users` へ変更
- 認証関連URLを `/users/...` に統一
- Google OAuthのコールバックURLを更新
- Google Cloud ConsoleのリダイレクトURIを更新
- `config.mailer_sender` を `ENV.fetch("MAILER_SENDER")` に変更
- `ApplicationMailer` の送信元を `ENV.fetch("MAILER_SENDER")` に統一
- `MAILER_SENDER` の送信元ドメインを認証済みドメインへ修正

## 確認方法
- [x] ログインできること
- [x] 新規登録できること
- [x] ログアウトできること
- [x] Googleログインできること
- [x] パスワードリセットメールを送信できること
- [x] パスワードリセットメール内のリンクからパスワードを更新できること
- [x] 更新後のパスワードでログインできること
- [x] 本番環境で上記動作を確認

## 影響範囲
### 影響がある画面・機能
- ログイン
- 新規登録
- ログアウト
- パスワードリセット
- Googleログイン

### 影響がないこと
- Watchlist機能
- 通知機能
- 設定画面（ログアウトを除く）

## 補足
本番確認時、パスワードリセットで500エラーが発生しました。
Renderログを確認したところ、Resendの送信元が `example.com` のままであることが原因と判明したため、送信元設定を `MAILER_SENDER` 環境変数へ統一しました。

送信元を `FanPocket <no-reply@fanpocket.fun>` としたことで、利用者にも分かりやすいメール表示となっています。