### PR TITLE
Google・LINEログインをSocialAccount対応に変更

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,7 +11,8 @@ module Users
     end
 
     def failure
-      redirect_with_alert('SNS認証に失敗しました。もう一度お試しください。')
+      redirect_to new_user_session_path,
+                  alert: 'SNS認証に失敗しました。もう一度お試しください。'
     end
 
     private
@@ -27,13 +28,22 @@ module Users
     end
 
     def handle_login(auth, provider_name)
-      @user = User.from_omniauth(auth)
+      result = User.from_omniauth(auth)
+      user = result[:user]
 
-      if @user.persisted?
-        sign_in_and_redirect @user, event: :authentication
+      flash[:notice] = login_message(result[:created], provider_name)
+
+      sign_in_and_redirect user, event: :authentication
+    rescue ActiveRecord::RecordInvalid
+      redirect_to new_user_registration_path,
+                  alert: "#{provider_name}アカウントでの登録に失敗しました。"
+    end
+
+    def login_message(created, provider_name)
+      if created
+        "#{provider_name}アカウントで新規登録しました。"
       else
-        redirect_to new_user_registration_url,
-                    alert: "#{provider_name}ログインに失敗しました。"
+        "#{provider_name}アカウントでログインしました。"
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  attr_accessor :omniauth_provider
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable,
@@ -17,15 +19,57 @@ class User < ApplicationRecord
   after_create_commit :send_welcome_email, if: -> { email.present? }
 
   def email_required?
-    provider != 'line'
+    omniauth_provider != 'line'
   end
 
   def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.email = auth.info.email
-      user.password = Devise.friendly_token[0, 20]
+    social_account = find_social_account(auth)
+
+    return { user: social_account.user, created: false } if social_account
+
+    user = create_user_with_social_account(auth)
+
+    { user: user, created: true }
+  end
+
+  def self.find_social_account(auth)
+    SocialAccount.find_by(
+      provider: auth.provider,
+      uid: auth.uid
+    )
+  end
+
+  def self.create_user_with_social_account(auth)
+    transaction do
+      user = create!(user_attributes_from(auth))
+
+      user.social_accounts.create!(
+        social_account_attributes_from(auth)
+      )
+
+      user
     end
   end
+
+  def self.user_attributes_from(auth)
+    {
+      email: auth.info.email.presence,
+      password: Devise.friendly_token[0, 20],
+      omniauth_provider: auth.provider
+    }
+  end
+
+  def self.social_account_attributes_from(auth)
+    {
+      provider: auth.provider,
+      uid: auth.uid
+    }
+  end
+
+  private_class_method :find_social_account,
+                       :create_user_with_social_account,
+                       :user_attributes_from,
+                       :social_account_attributes_from
 
   def link_social_account(auth)
     return :already_linked if already_linked?(auth)


### PR DESCRIPTION
## 概要
Google・LINEログインを `users.provider` / `users.uid` ではなく `social_accounts` を利用する認証方式へ変更しました。
また、LINEログイン時にメールアドレスが取得できない場合でも新規登録・ログインできるよう対応しました。

## 背景
認証情報を `users` テーブルから `social_accounts` テーブルへ移行し、1ユーザーが複数のSNSアカウントを連携できる構成にするため。

closes: #133

## 変更内容
- `User.from_omniauth` を `social_accounts` を利用する実装へ変更
- 既存の `SocialAccount` が存在する場合は紐づくユーザーでログインするよう変更
- `SocialAccount` が存在しない場合は `User` と `SocialAccount` をトランザクション内で作成するよう変更
- LINEログイン時はメールアドレスが取得できないケースを考慮し、メールアドレスなしでも登録できるよう対応
- `attr_accessor :omniauth_provider` を追加し、プロバイダーごとにバリデーションを切り替えるよう変更
- SNSログイン後のフラッシュメッセージを、新規登録・既存ログインで出し分けるよう変更
- `handle_login` をリファクタリングし、フラッシュメッセージ生成処理を `login_message` メソッドへ切り出し

## 確認方法
- メールアドレス登録済みユーザーでGoogleログインできること
- メールアドレス登録済みユーザーでLINEログインできること
- Googleアカウントで新規登録できること
- LINEアカウント（メールアドレスなし）で新規登録できること
- 新規登録時・既存ログイン時でフラッシュメッセージが正しく表示されること
- ウェルカムメールがGoogle新規登録時に送信されること
- RuboCopで問題がないこと

## 影響範囲
- **影響がある画面/機能**
  - Googleログイン
  - LINEログイン
  - OmniAuth認証処理
  - 新規登録フロー
- **影響がないこと（あれば）**
  - メールアドレス・パスワードによる通常ログイン
  - Watchlist関連機能
  - 通知機能


## 補足
- `users.provider` / `users.uid` を利用する実装から `social_accounts` ベースの認証へ移行しました。
- LINEログインでメールアドレスが取得できないケースにも対応し、将来的な複数SNS連携へ対応しやすい構成になりました。
- `User.from_omniauth` の責務分割や `handle_login` のリファクタリングを行い、コードの可読性も改善しました。