### PR TITLE
LINE通知を実装

### DIFF
--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -17,8 +17,10 @@ env:
   REDIS_URL: ${{ secrets.REDIS_URL }}
   GOOGLE_CLIENT_ID: dummy_google_client_id
   GOOGLE_CLIENT_SECRET: dummy_google_client_secret
-  LINE_CHANNEL_ID: dummy_line_channel_id
-  LINE_CHANNEL_SECRET: dummy_line_channel_secret
+  LINE_LOGIN_CHANNEL_ID: dummy_line_login_channel_id
+  LINE_LOGIN_CHANNEL_SECRET: dummy_line_login_channel_secret
+  LINE_MESSAGING_CHANNEL_SECRET: dummy_line_messaging_channel_secret
+  LINE_MESSAGING_CHANNEL_ACCESS_TOKEN: dummy_line_messaging_channel_access_token
   MAILER_SENDER: ${{ secrets.MAILER_SENDER }}
 
 jobs:

--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -20,7 +20,7 @@ env:
   LINE_LOGIN_CHANNEL_ID: dummy_line_login_channel_id
   LINE_LOGIN_CHANNEL_SECRET: dummy_line_login_channel_secret
   LINE_MESSAGING_CHANNEL_SECRET: dummy_line_messaging_channel_secret
-  LINE_MESSAGING_CHANNEL_ACCESS_TOKEN: dummy_line_messaging_channel_access_token
+  LINE_MESSAGING_CHANNEL_ACCESS_TOKEN:  ${{ secrets.LINE_MESSAGING_CHANNEL_ACCESS_TOKEN }}
   MAILER_SENDER: ${{ secrets.MAILER_SENDER }}
 
 jobs:

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -50,6 +50,8 @@ module Users
     def handle_account_linking(auth, provider_name)
       result = current_user.link_social_account(auth)
 
+      send_line_linked_message(auth) if line_linked_successfully?(auth, result)
+
       redirect_to settings_path,
                   flash_type(result) => flash_message(result, provider_name)
     end
@@ -73,6 +75,22 @@ module Users
 
     def linking?
       request.env.dig('omniauth.params', 'purpose') == 'link'
+    end
+
+    def line_linked_successfully?(auth, result)
+      result == :success && auth.provider == 'line'
+    end
+
+    def send_line_linked_message(auth)
+      LineMessagingService.push_text(
+        auth.uid,
+        <<~MESSAGE.strip
+          LINE連携が完了しました！🎉
+
+          FanPocketをご利用いただきありがとうございます。
+          大切な予定を見逃さないよう、LINEでお知らせします。
+        MESSAGE
+      )
     end
   end
 end

--- a/app/services/line_messaging_service.rb
+++ b/app/services/line_messaging_service.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'json'
+
+class LineMessagingService
+  ENDPOINT = 'https://api.line.me/v2/bot/message/push'
+
+  class << self
+    def push_text(line_user_id, text)
+      response = send_request(line_user_id, text)
+
+      return true if response.is_a?(Net::HTTPSuccess)
+
+      log_error(response)
+      false
+    end
+
+    def send_line_notification(user, content)
+      line_account = user.social_accounts.find_by(provider: 'line')
+      return unless line_account
+
+      push_text(line_account.uid, content)
+    end
+
+    private
+
+    def send_request(line_user_id, text)
+      uri = URI(ENDPOINT)
+      request = build_request(uri, line_user_id, text)
+
+      Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+        http.request(request)
+      end
+    end
+
+    def build_request(uri, line_user_id, text)
+      request = Net::HTTP::Post.new(uri)
+      request['Content-Type'] = 'application/json'
+      request['Authorization'] = authorization_header
+      request.body = message_body(line_user_id, text).to_json
+      request
+    end
+
+    def authorization_header
+      token = ENV.fetch('LINE_MESSAGING_CHANNEL_ACCESS_TOKEN')
+      "Bearer #{token}"
+    end
+
+    def message_body(line_user_id, text)
+      {
+        to: line_user_id,
+        messages: [{ type: 'text', text: text }]
+      }
+    end
+
+    def log_error(response)
+      Rails.logger.error(
+        "LINE message failed: status=#{response.code} body=#{response.body}"
+      )
+    end
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -280,8 +280,8 @@ Devise.setup do |config|
                 ENV.fetch("GOOGLE_CLIENT_SECRET")
 
   config.omniauth :line,
-                ENV.fetch("LINE_CHANNEL_ID"),
-                ENV.fetch("LINE_CHANNEL_SECRET"),
+                ENV.fetch("LINE_LOGIN_CHANNEL_ID"),
+                ENV.fetch("LINE_LOGIN_CHANNEL_SECRET"),
                 scope: 'profile openid email'
 
   # ==> Warden configuration

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -50,7 +50,7 @@ namespace :notification do
         NotificationMailer.day_before_notice(user_email, title, content).deliver_now
 
         LineMessagingService.send_line_notification(user, content)
-        
+
         puts "前日通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
 
         # 1秒待つ（Resendのレートリミット対策）

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -17,6 +17,9 @@ namespace :notification do
         content    = "気になっている「#{watchlist.display_title}」の締め切りまであと3日です。忘れないうちにチェックしてみませんか？"
 
         NotificationMailer.three_days_ago_notice(user_email, title, content).deliver_now
+
+        LineMessagingService.send_line_notification(user, content)
+
         puts "通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
 
         # 1秒待つ（Resendのレートリミット対策）
@@ -45,6 +48,9 @@ namespace :notification do
         content    = "気になっている「#{watchlist.display_title}」の締め切りは明日です。大切な予定を見逃さないようにご確認ください。"
 
         NotificationMailer.day_before_notice(user_email, title, content).deliver_now
+
+        LineMessagingService.send_line_notification(user, content)
+        
         puts "前日通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
 
         # 1秒待つ（Resendのレートリミット対策）
@@ -76,6 +82,9 @@ namespace :notification do
         content    = "気になっている「#{watchlist.display_title}」の締め切りは本日です。大切な予定を見逃さないようにご確認ください。"
 
         NotificationMailer.today_notice(user_email, title, content).deliver_now
+
+        LineMessagingService.send_line_notification(user, content)
+
         puts "当日締切通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
 
         # 1秒待つ（Resendのレートリミット対策）
@@ -104,6 +113,9 @@ namespace :notification do
         content    = "気になっている「#{watchlist.display_title}」の開始は本日です。詳細をチェックしてみませんか？"
 
         NotificationMailer.start_notice(user_email, title, content).deliver_now
+
+        LineMessagingService.send_line_notification(user, content)
+
         puts "当日開始通知送信完了: [Watchlist ID: #{watchlist.id}] to [User: #{user_email}]"
 
         # 1秒待つ（Resendのレートリミット対策）


### PR DESCRIPTION
## 概要
LINE通知機能を実装しました。
LINE公式アカウントと連携し、通知送信および関連処理を追加しました。

## 背景
LINE通知機能を実現し、ユーザーがメールだけでなくLINEでも大切な予定の通知を受け取れるようにするため。
（closes: #84）

## 変更内容
- LINE Messaging APIを利用した通知機能を実装
- `LineMessagingService`を作成し、LINE送信処理を実装
- LINE連携完了時に通知メッセージを送信する処理を追加
- 通知Rakeタスク（3日前・前日・当日・開始日）へLINE通知を追加
- LINE通知処理を`LineMessagingService.send_line_notification`へ共通化し、Rake内の重複コードを削除
- RuboCop指摘（`Metrics/MethodLength`・`Metrics/AbcSize`）に対応するため、Serviceをリファクタリング
- GitHub ActionsでLINE Messaging APIのアクセストークンをGitHub Secretsから参照するよう修正

## 確認方法
- LINEログイン・LINE連携ができること
- LINE連携完了時に通知が届くこと
- GitHub Actionsから各通知Rakeタスク（3日前・前日・当日・開始日）を実行し、メール・LINE通知が正常に届くこと
- LINE公式アカウントを再度友だち追加し、あいさつメッセージが表示されること
- `bundle exec rubocop`でエラーがないこと

## 影響範囲
- 影響がある画面/機能
  - LINEアカウント連携
  - LINE通知機能
  - 通知Rakeタスク
  - LINE公式アカウント
  - GitHub Actionsの通知用環境変数
- 影響がないこと
  - メール通知の既存仕様
  - Watchlist登録・編集機能

## 補足
LINE通知処理をServiceクラスへ集約し、Rakeタスク側の責務をシンプルにしました。
今後は通知処理の追加・変更も`LineMessagingService`を中心に保守できる構成としています。
LINE公式アカウントのあいさつメッセージもFanPocket向けに更新しました。

GitHub Actionsでダミーのアクセストークンを使用していたため、
LINE Messaging APIから`401 Authentication failed`が返されていました。

`LINE_MESSAGING_CHANNEL_ACCESS_TOKEN`をGitHub Secrets参照へ変更し、
LINE通知が正常に送信されることを確認しました。