### PR TITLE
Google Analyticsを導入しタブタイトルを変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html data-theme="night">
   <head>
-    <title>App</title>
+    <title>FanPocket</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <%= csrf_meta_tags %>
@@ -13,6 +13,19 @@
 
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700;800&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
+
+    <% if Rails.env.production? && ENV["GA_MEASUREMENT_ID"].present? %>
+      <!-- Google tag (gtag.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ENV["GA_MEASUREMENT_ID"] %>"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', '<%= ENV["GA_MEASUREMENT_ID"] %>');
+      </script>
+    <% end %>
+  
   </head>
 
   <body class="relative min-h-screen overflow-x-hidden">


### PR DESCRIPTION
## 概要
Google Analytics 4（GA4）を導入し、アクセス解析ができるようにしました。
あわせてブラウザのタブタイトルを「FanPocket」に変更しました。

## 背景
アクセス数やユーザー数などを把握し、サービスの利用状況を分析できるようにするため。
（closes: #136）

## 変更内容
- Google Analytics 4（GA4）の計測タグを追加
- 本番環境のみGA4を読み込むように設定
- Measurement IDを環境変数（`GA_MEASUREMENT_ID`）から取得するように設定
- ブラウザのタブタイトルを「FanPocket」に変更

## 確認方法
- Renderへデプロイ
- FanPocketへアクセス
- Google Analytics 4でアクセスが計測されることを確認
- ブラウザのタブタイトルが「FanPocket」と表示されることを確認

## 影響範囲
- 影響がある画面/機能
  - 全ページ（Google Analyticsの計測）
  - ブラウザのタブタイトル
- 影響がないこと（あれば）
  - アプリの既存機能・画面遷移・通知機能

## スクリーンショット
- Google Analyticsでアクセスが計測されている画面
<img width="1919" height="989" alt="image" src="https://github.com/user-attachments/assets/4ac80379-08b9-4747-9802-88f05ee216cf" />

- タブタイトルが「FanPocket」と表示されている画面
<img width="179" height="56" alt="image" src="https://github.com/user-attachments/assets/c212da16-2bd3-49f4-9e95-53fe4473e87b" />


## 補足
- `GA_MEASUREMENT_ID` は環境変数で管理しています。
- GA4は本番環境でのみ読み込まれるようにしています。