### PR TITLE
LINEログイン時に友だち追加を促す

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -282,7 +282,10 @@ Devise.setup do |config|
   config.omniauth :line,
                 ENV.fetch("LINE_LOGIN_CHANNEL_ID"),
                 ENV.fetch("LINE_LOGIN_CHANNEL_SECRET"),
-                scope: 'profile openid email'
+                scope: "profile openid email",
+                authorize_params: {
+                  bot_prompt: "aggressive"
+                }
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
## 概要
LINEログイン・LINE連携時に、FanPocket公式LINEの友だち追加を促すようにしました。

## 背景
LINE通知を利用するためには公式LINEの友だち追加が必要ですが、これまではユーザーが手動で追加する必要があり、導線が分かりにくい状態でした。
（closes: #138）

## 変更内容
- LINE Loginの認可リクエストに`bot_prompt: "aggressive"`を追加
- `authorize_params`を利用して`bot_prompt`をLINEへ渡すように変更
- LINEログイン・設定画面からのLINE連携時に、公式LINEの友だち追加（またはブロック解除）を促すように変更

## 確認方法
1. LINEログインを実行する
2. 友だち追加（またはブロック解除）の画面が表示されることを確認する
3. 友だち追加後、FanPocket公式LINEからメッセージが届くことを確認する
4. 設定画面からのLINE連携でも同様の動作になることを確認する
5. 別ユーザーでもLINE連携時に公式LINEが友だち追加されることを確認する

## 影響範囲
- 影響がある画面/機能
  - LINEログイン
  - 設定画面のLINE連携
- 影響がないこと（あれば）
  - Googleログイン
  - メールログイン
  - LINE通知送信処理

## スクリーンショット
<img width="1008" height="993" alt="image" src="https://github.com/user-attachments/assets/2a17be66-112a-480c-81da-f0c25c967ce9" />

## 補足
`bot_prompt`は`authorize_params`経由で設定することで、認可リクエストに正しく付与されることを確認しました。

また、別ユーザーによる動作確認を行い、LINE連携時に公式LINEが友だち追加されることを確認しました。