### PR TITLE
開始10分前・締切3時間前のLINE通知をFlex Message対応

### DIFF
--- a/app/models/notification_delivery.rb
+++ b/app/models/notification_delivery.rb
@@ -12,7 +12,9 @@ class NotificationDelivery < ApplicationRecord
     deadline_three_days_before: 0,
     deadline_day_before: 1,
     deadline_same_day: 2,
-    start_same_day: 3
+    start_same_day: 3,
+    start_ten_minutes_before: 4,
+    deadline_three_hours_before: 5
   }
 
   validates :channel, presence: true

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -67,34 +67,40 @@ class Watchlist < ApplicationRecord
 
   # 3日前通知用
   scope :alert_three_days_prior, lambda {
-    start_of_day = 3.days.from_now.beginning_of_day
-    end_of_day   = 3.days.from_now.end_of_day
-
-    where(is_done: false, end_at: start_of_day..end_of_day)
+    where(is_done: false, end_at: 3.days.from_now.all_day)
   }
 
-  # 前日通知用：締め切り（end_at）が「明日」の未完了タスク
+  # 前日通知用
   scope :alert_day_before, lambda {
-    start_of_day = 1.day.from_now.beginning_of_day
-    end_of_day   = 1.day.from_now.end_of_day
-
-    where(is_done: false, end_at: start_of_day..end_of_day)
+    where(is_done: false, end_at: 1.day.from_now.all_day)
   }
 
-  # 当日通知用：締め切り（end_at）が「今日」の未完了タスク
+  # 当日通知用
   scope :alert_same_day, lambda {
-    start_of_day = Time.zone.now.beginning_of_day
-    end_of_day   = Time.zone.now.end_of_day
-
-    where(is_done: false, end_at: start_of_day..end_of_day)
+    where(is_done: false, end_at: Time.current.all_day)
   }
 
   # 今日が開始日かつ未完了のデータを取得
   scope :starting_today, lambda {
-    where(
-      start_at: Time.zone.now.beginning_of_day..Time.zone.now.end_of_day,
-      is_done: false
-    )
+    where(start_at: Time.current.all_day, is_done: false)
+  }
+
+  # 開始10分前LINE通知用
+  scope :starting_within_ten_minutes, lambda { |current_time = Time.current|
+    where(is_done: false)
+      .where('start_at > ? AND start_at <= ?', current_time, current_time + 10.minutes)
+  }
+
+  # 締切3時間前LINE通知用
+  scope :deadline_three_hours_before, lambda { |current_time = Time.current|
+    notification_limit = current_time + 3.hours
+
+    where(is_done: false)
+      .where(
+        'end_at > ? AND end_at <= ?',
+        notification_limit - 10.minutes,
+        notification_limit
+      )
   }
 
   private

--- a/app/services/line_flex_message_builder.rb
+++ b/app/services/line_flex_message_builder.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+class LineFlexMessageBuilder
+  class << self
+    def call(line_user_id, title, message, url)
+      flex_message_body(line_user_id, title, message, url)
+    end
+
+    private
+
+    def flex_message_body(line_user_id, title, message, url)
+      {
+        to: line_user_id,
+        messages: [
+          {
+            type: 'flex',
+            altText: "#{title}のお知らせ",
+            contents: flex_contents(title, message, url)
+          }
+        ]
+      }
+    end
+
+    def flex_contents(title, message, url)
+      {
+        type: 'bubble',
+        body: body_contents(title, message),
+        footer: footer_contents(url)
+      }
+    end
+
+    def body_contents(title, message)
+      {
+        type: 'box',
+        layout: 'vertical',
+        spacing: 'md',
+        contents: [
+          title_contents(title),
+          message_contents(message)
+        ]
+      }
+    end
+
+    def title_contents(title)
+      {
+        type: 'text',
+        text: title,
+        weight: 'bold',
+        size: 'lg',
+        wrap: true
+      }
+    end
+
+    def message_contents(message)
+      {
+        type: 'text',
+        text: message,
+        size: 'md',
+        wrap: true
+      }
+    end
+
+    def footer_contents(url)
+      {
+        type: 'box',
+        layout: 'vertical',
+        contents: [button_contents(url)]
+      }
+    end
+
+    def button_contents(url)
+      {
+        type: 'button',
+        style: 'primary',
+        action: {
+          type: 'uri',
+          label: 'FanPocketで確認する',
+          uri: url
+        }
+      }
+    end
+  end
+end

--- a/app/services/line_messaging_service.rb
+++ b/app/services/line_messaging_service.rb
@@ -16,11 +16,18 @@ class LineMessagingService
       false
     end
 
-    def send_line_notification(user, content)
-      line_account = user.social_accounts.find_by(provider: 'line')
-      return unless line_account
+    def push_flex(line_user_id, title, message, url)
+      response = send_flex_request(
+        line_user_id,
+        title,
+        message,
+        url
+      )
 
-      push_text(line_account.uid, content)
+      return true if response.is_a?(Net::HTTPSuccess)
+
+      log_error(response)
+      false
     end
 
     private
@@ -34,11 +41,33 @@ class LineMessagingService
       end
     end
 
+    def send_flex_request(line_user_id, title, message, url)
+      uri = URI(ENDPOINT)
+      request = build_flex_request(uri, line_user_id, title, message, url)
+
+      Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+        http.request(request)
+      end
+    end
+
     def build_request(uri, line_user_id, text)
       request = Net::HTTP::Post.new(uri)
       request['Content-Type'] = 'application/json'
       request['Authorization'] = authorization_header
       request.body = message_body(line_user_id, text).to_json
+      request
+    end
+
+    def build_flex_request(uri, line_user_id, title, message, url)
+      request = Net::HTTP::Post.new(uri)
+      request['Content-Type'] = 'application/json'
+      request['Authorization'] = authorization_header
+      request.body = LineFlexMessageBuilder.call(
+        line_user_id,
+        title,
+        message,
+        url
+      ).to_json
       request
     end
 

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -9,5 +9,9 @@ class NotificationService
     def send_night_notifications
       NightNotificationService.call
     end
+
+    def send_realtime_line_notifications
+      RealtimeLineNotificationService.call
+    end
   end
 end

--- a/app/services/realtime_line_notification_service.rb
+++ b/app/services/realtime_line_notification_service.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+class RealtimeLineNotificationService
+  class << self
+    include NotificationDeliverySupport
+
+    def call
+      send_start_ten_minutes_before
+      send_deadline_three_hours_before
+    end
+
+    private
+
+    def send_start_ten_minutes_before
+      send_notifications(
+        Watchlist.starting_within_ten_minutes,
+        log_type: '開始10分前LINE',
+        notification_type: :start_ten_minutes_before,
+        message: start_ten_minutes_before_message
+      )
+    end
+
+    def send_deadline_three_hours_before
+      send_notifications(
+        Watchlist.deadline_three_hours_before,
+        log_type: '締切3時間前LINE',
+        notification_type: :deadline_three_hours_before,
+        message: deadline_three_hours_before_message
+      )
+    end
+
+    def send_notifications(targets, log_type:, notification_type:, message:)
+      targets = targets.includes(user: :social_accounts)
+
+      log_start(log_type, targets.count)
+
+      targets.find_each do |watchlist|
+        send_notification(watchlist, log_type:, notification_type:, message:)
+      end
+
+      log_finish(log_type)
+    end
+
+    def send_notification(watchlist, log_type:, notification_type:, message:)
+      line_account = line_account_for(watchlist.user)
+
+      return unless line_account
+      return if delivered?(watchlist, :line, notification_type)
+
+      deliver_notification(watchlist, line_account, log_type:, notification_type:, message:)
+    rescue StandardError => e
+      log_error(log_type, watchlist.id, e)
+    end
+
+    def deliver_notification(
+      watchlist,
+      line_account,
+      notification_type:,
+      message:,
+      log_type:
+    )
+      sent = LineMessagingService.push_flex(
+        line_account.uid,
+        notification_title(watchlist),
+        message,
+        watchlist_url(watchlist)
+      )
+
+      return unless sent
+
+      record_delivery(watchlist, :line, notification_type)
+      log_success(log_type, watchlist.id, line_account.uid)
+    end
+
+    def notification_title(watchlist)
+      "🌟 #{watchlist.display_title}"
+    end
+
+    def start_ten_minutes_before_message
+      "開始まであと10分です。\n\nまもなく始まります。\n詳細をご確認ください。"
+    end
+
+    def deadline_three_hours_before_message
+      "締め切りまであと3時間です。\n\n大切な予定を見逃さないようご確認ください。"
+    end
+
+    def watchlist_url(watchlist)
+      Rails.application.routes.url_helpers.watchlist_url(
+        watchlist,
+        Rails.application.config.action_mailer.default_url_options
+      )
+    end
+
+    def line_account_for(user)
+      user&.social_accounts&.find do |account|
+        account.provider == 'line'
+      end
+    end
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,7 +79,10 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   
   # Render本番環境のURLを設定（自身のRender URLに変更してください）
-  config.action_mailer.default_url_options = { host: 'fanpocket.onrender.com' }
+  config.action_mailer.default_url_options = { 
+    host: 'fanpocket.onrender.com',
+    protocol: 'https'
+  }
 
   # SMTP経由でResendから送信する設定
   config.action_mailer.smtp_settings = {

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -10,4 +10,9 @@ namespace :notification do
   task send_night: :environment do
     NotificationService.send_night_notifications
   end
+
+  desc '直前LINE通知を送信する'
+  task send_realtime_line: :environment do
+    NotificationService.send_realtime_line_notifications
+  end
 end


### PR DESCRIPTION
## 概要
開始10分前・締切3時間前のリアルタイムLINE通知を実装しました。  
Flex Messageに対応し、予定詳細へ遷移できるボタンを追加しました。

## 背景
LINE通知をより実用的にし、予定開始直前や締切直前にユーザーがすぐ行動できるようにするため。  
（closes: #89）

## 変更内容
- 開始10分前・締切3時間前のLINE通知を実装
- `RealtimeLineNotificationService` を作成し、リアルタイム通知処理を追加
- 開始10分前・締切3時間前の通知対象を取得するスコープを追加
- LINE通知をFlex Message対応に変更
- 通知内に「FanPocketで確認する」ボタンを追加し、予定詳細画面へ遷移できるように変更
- `LineFlexMessageBuilder` を作成し、Flex Message生成処理を分離
- NotificationDeliveryによる重複送信防止に対応
- 通知処理を共通化し、リファクタリングを実施
- 不要になった `send_line_notification` を削除
- RuboCop対応

## 確認方法
1. LINE連携済みユーザーで開始日時を現在時刻から10分以内に設定した予定を作成
2. `docker compose exec web bundle exec rails notification:send_realtime_line` を実行
3. 開始10分前のFlex Messageが送信され、「FanPocketで確認する」ボタンから予定詳細画面へ遷移できることを確認
4. 同じコマンドを再実行し、重複送信されないことを確認
5. 締切日時を現在時刻から約3時間後に設定した予定で、締切3時間前通知も同様に確認

## 影響範囲
- **影響がある画面/機能**
  - LINEリアルタイム通知（開始10分前・締切3時間前）
  - 通知送信処理
- **影響がないこと**
  - メール通知（3日前・前日・当日・開始当日）
  - LINE連携・LINE連携完了メッセージ

## 補足
- LINE通知は開始10分前・締切3時間前のみFlex Messageに対応
- 通知済み履歴（NotificationDelivery）により重複送信されないことを確認済み
- Flex Messageのデザイン改善は別Issueで対応予定