### PR TITLE
アプリ内通知を実装

### DIFF
--- a/app/controllers/internal/notifications_controller.rb
+++ b/app/controllers/internal/notifications_controller.rb
@@ -10,6 +10,7 @@ module Internal
     def create
       NotificationService.send_morning_notifications if morning_time?
       NotificationService.send_night_notifications if night_time?
+      NotificationService.send_realtime_line_notifications
 
       head :ok
     end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class NotificationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @notifications = current_user.notifications.recent
+  end
+
+  def show
+    @notification = current_user.notifications.find(params[:id])
+    @notification.mark_as_read!
+
+    redirect_to watchlist_path(@notification.watchlist)
+  end
+end

--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module NotificationsHelper
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Notification < ApplicationRecord
+  belongs_to :user
+  belongs_to :watchlist
+
+  enum :notification_type, {
+    deadline_three_days_before: 0,
+    deadline_day_before: 1,
+    deadline_same_day: 2,
+    start_same_day: 3,
+    start_ten_minutes_before: 4,
+    deadline_three_hours_before: 5
+  }
+
+  validates :notification_type, presence: true
+  validates :title, presence: true
+  validates :message, presence: true
+
+  scope :recent, -> { order(created_at: :desc) }
+  scope :unread, -> { where(read_at: nil) }
+  scope :read, -> { where.not(read_at: nil) }
+
+  def read?
+    read_at.present?
+  end
+
+  def mark_as_read!
+    update!(read_at: Time.current) unless read?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
 
   has_many :watchlists, dependent: :destroy
   has_many :social_accounts, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   after_create_commit :send_welcome_email, if: -> { email.present? }
 

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -2,7 +2,9 @@
 
 class Watchlist < ApplicationRecord
   belongs_to :user
+
   has_many :notification_deliveries, dependent: :destroy
+  has_many :notifications, dependent: :destroy
 
   before_validation :set_end_at_to_end_of_day, if: :end_at_time_blank?
 

--- a/app/services/in_app_notification_service.rb
+++ b/app/services/in_app_notification_service.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class InAppNotificationService
+  class << self
+    def create!(watchlist:, notification_type:, title:, message:)
+      Notification.find_or_create_by!(
+        user: watchlist.user,
+        watchlist: watchlist,
+        notification_type: notification_type
+      ) do |notification|
+        notification.title = title
+        notification.message = message
+      end
+    end
+  end
+end

--- a/app/services/morning_notification_service.rb
+++ b/app/services/morning_notification_service.rb
@@ -32,16 +32,30 @@ class MorningNotificationService
     def deliver_deadline_same_day_notification(watchlist, user)
       content = deadline_same_day_content(watchlist)
 
-      NotificationMailer.today_notice(
-        user.email,
-        watchlist.title,
-        content
-      ).deliver_now
+      create_deadline_same_day_notification(watchlist, content)
+      send_deadline_same_day_email(watchlist, user, content)
 
       record_delivery(watchlist, :email, :deadline_same_day)
 
       log_success('当日締切', watchlist.id, user.email)
       sleep 1
+    end
+
+    def create_deadline_same_day_notification(watchlist, content)
+      InAppNotificationService.create!(
+        watchlist: watchlist,
+        notification_type: :deadline_same_day,
+        title: '締め切りは本日です',
+        message: content
+      )
+    end
+
+    def send_deadline_same_day_email(watchlist, user, content)
+      NotificationMailer.today_notice(
+        user.email,
+        watchlist.title,
+        content
+      ).deliver_now
     end
 
     def deadline_same_day_content(watchlist)
@@ -70,16 +84,30 @@ class MorningNotificationService
     def deliver_start_same_day_notification(watchlist, user)
       content = start_same_day_content(watchlist)
 
-      NotificationMailer.start_notice(
-        user.email,
-        watchlist.title,
-        content
-      ).deliver_now
+      create_start_same_day_notification(watchlist, content)
+      send_start_same_day_email(watchlist, user, content)
 
       record_delivery(watchlist, :email, :start_same_day)
 
       log_success('当日開始', watchlist.id, user.email)
       sleep 1
+    end
+
+    def create_start_same_day_notification(watchlist, content)
+      InAppNotificationService.create!(
+        watchlist: watchlist,
+        notification_type: :start_same_day,
+        title: '開始は本日です',
+        message: content
+      )
+    end
+
+    def send_start_same_day_email(watchlist, user, content)
+      NotificationMailer.start_notice(
+        user.email,
+        watchlist.title,
+        content
+      ).deliver_now
     end
 
     def start_same_day_content(watchlist)

--- a/app/services/night_notification_service.rb
+++ b/app/services/night_notification_service.rb
@@ -24,11 +24,7 @@ class NightNotificationService
     def send_three_days_prior_notification(watchlist)
       user = watchlist.user
       return unless user
-      return if delivered?(
-        watchlist,
-        :email,
-        :deadline_three_days_before
-      )
+      return if delivered?(watchlist, :email, :deadline_three_days_before)
 
       deliver_three_days_prior_notification(watchlist, user)
     rescue StandardError => e
@@ -38,16 +34,29 @@ class NightNotificationService
     def deliver_three_days_prior_notification(watchlist, user)
       content = three_days_prior_content(watchlist)
 
+      create_three_days_prior_notification(watchlist, content)
+      send_three_days_prior_email(watchlist, user, content)
+      record_delivery(watchlist, :email, :deadline_three_days_before)
+
+      log_success('締切3日前', watchlist.id, user.email)
+      sleep 1
+    end
+
+    def create_three_days_prior_notification(watchlist, content)
+      InAppNotificationService.create!(
+        watchlist: watchlist,
+        notification_type: :deadline_three_days_before,
+        title: '締め切りの3日前です',
+        message: content
+      )
+    end
+
+    def send_three_days_prior_email(watchlist, user, content)
       NotificationMailer.three_days_ago_notice(
         user.email,
         watchlist.title,
         content
       ).deliver_now
-
-      record_delivery(watchlist, :email, :deadline_three_days_before)
-
-      log_success('締切3日前', watchlist.id, user.email)
-      sleep 1
     end
 
     def three_days_prior_content(watchlist)
@@ -68,11 +77,7 @@ class NightNotificationService
     def send_day_before_notification(watchlist)
       user = watchlist.user
       return unless user
-      return if delivered?(
-        watchlist,
-        :email,
-        :deadline_day_before
-      )
+      return if delivered?(watchlist, :email, :deadline_day_before)
 
       deliver_day_before_notification(watchlist, user)
     rescue StandardError => e
@@ -82,16 +87,29 @@ class NightNotificationService
     def deliver_day_before_notification(watchlist, user)
       content = day_before_content(watchlist)
 
+      create_day_before_notification(watchlist, content)
+      send_day_before_email(watchlist, user, content)
+      record_delivery(watchlist, :email, :deadline_day_before)
+
+      log_success('締切前日', watchlist.id, user.email)
+      sleep 1
+    end
+
+    def create_day_before_notification(watchlist, content)
+      InAppNotificationService.create!(
+        watchlist: watchlist,
+        notification_type: :deadline_day_before,
+        title: '明日締め切りです',
+        message: content
+      )
+    end
+
+    def send_day_before_email(watchlist, user, content)
       NotificationMailer.day_before_notice(
         user.email,
         watchlist.title,
         content
       ).deliver_now
-
-      record_delivery(watchlist, :email, :deadline_day_before)
-
-      log_success('締切前日', watchlist.id, user.email)
-      sleep 1
     end
 
     def day_before_content(watchlist)

--- a/app/services/realtime_line_notification_service.rb
+++ b/app/services/realtime_line_notification_service.rb
@@ -16,6 +16,7 @@ class RealtimeLineNotificationService
         Watchlist.starting_within_ten_minutes,
         log_type: '開始10分前LINE',
         notification_type: :start_ten_minutes_before,
+        title: '開始まであと10分です',
         message: start_ten_minutes_before_message
       )
     end
@@ -25,23 +26,26 @@ class RealtimeLineNotificationService
         Watchlist.deadline_three_hours_before,
         log_type: '締切3時間前LINE',
         notification_type: :deadline_three_hours_before,
+        title: '締め切りまであと3時間です',
         message: deadline_three_hours_before_message
       )
     end
 
-    def send_notifications(targets, log_type:, notification_type:, message:)
+    def send_notifications(targets, log_type:, notification_type:, title:, message:)
       targets = targets.includes(user: :social_accounts)
 
       log_start(log_type, targets.count)
 
       targets.find_each do |watchlist|
-        send_notification(watchlist, log_type:, notification_type:, message:)
+        send_notification(watchlist, log_type:, notification_type:, title:, message:)
       end
 
       log_finish(log_type)
     end
 
-    def send_notification(watchlist, log_type:, notification_type:, message:)
+    def send_notification(watchlist, log_type:, notification_type:, title:, message:)
+      create_in_app_notification(watchlist, notification_type, title, message)
+
       line_account = line_account_for(watchlist.user)
 
       return unless line_account
@@ -70,6 +74,15 @@ class RealtimeLineNotificationService
 
       record_delivery(watchlist, :line, notification_type)
       log_success(log_type, watchlist.id, line_account.uid)
+    end
+
+    def create_in_app_notification(watchlist, notification_type, title, message)
+      InAppNotificationService.create!(
+        watchlist: watchlist,
+        notification_type: notification_type,
+        title: title,
+        message: message
+      )
     end
 
     def notification_title(watchlist)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -36,6 +36,27 @@
       </span>
     </div>
 
-    <div class="absolute right-4 w-6" aria-hidden="true"></div>
+    <div class="absolute right-5 md:right-6 flex items-center">
+      <%= link_to notifications_path,
+                  class: "relative flex items-center justify-center
+                          text-primary hover:opacity-70 transition-opacity",
+                  aria: { label: "通知を確認する" } do %>
+        <span
+          class="material-symbols-outlined text-[28px] md:text-[32px]"
+          style="font-variation-settings: 'FILL' <%= current_page?(notifications_path) ? 1 : 0 %>;">
+          notifications
+        </span>
+
+        <% unread_count = current_user.notifications.unread.count %>
+        <% if unread_count.positive? %>
+          <span class="absolute -right-2 -top-2 flex h-5 min-w-5
+             md:h-6 md:min-w-6
+             items-center justify-center rounded-full
+             bg-red-500 px-1 text-xs md:text-sm font-bold text-white">
+             <%= unread_count > 99 ? "99+" : unread_count %>
+          </span>
+        <% end %>
+      <% end %>
+    </div>
   </div>
 </header>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,0 +1,70 @@
+<%= render "layouts/app_navigation", back_path: watchlists_path %>
+
+<main class="w-full max-w-2xl mx-auto px-4 sm:px-6 mt-10 md:mt-14 pb-28 md:pb-12">
+  <div class="mb-8 md:mb-10 text-center">
+    <h2 class="font-headline font-extrabold text-3xl md:text-4xl tracking-tight text-primary">
+      通知
+    </h2>
+
+    <p class="mt-2 text-[#4f5052] text-sm md:text-base">
+      大切な予定のお知らせを確認できます
+    </p>
+  </div>
+
+  <% if @notifications.any? %>
+    <div class="space-y-4">
+      <% @notifications.each do |notification| %>
+        <%= link_to notification_path(notification),
+                    class: "block rounded-2xl bg-white p-5 shadow-sm border transition hover:shadow-md #{notification.read? ? 'border-gray-100 opacity-70' : 'border-primary'}" do %>
+          <div class="flex items-start gap-3">
+            <div class="shrink-0">
+              <span class="material-symbols-outlined text-primary text-2xl">
+                notifications
+              </span>
+            </div>
+
+            <div class="min-w-0 flex-1">
+              <div class="flex items-start justify-between gap-3">
+                <h3 class="font-bold text-gray-800">
+                  <%= notification.title %>
+                </h3>
+
+                <% unless notification.read? %>
+                  <span class="shrink-0 rounded-full bg-primary px-2.5 py-1 text-xs font-bold text-white">
+                    未読
+                  </span>
+                <% end %>
+              </div>
+
+              <p class="mt-2 whitespace-pre-line text-sm leading-relaxed text-gray-600">
+                <%= notification.message %>
+              </p>
+
+              <p class="mt-3 text-xs text-gray-400">
+                <%= l notification.created_at, format: :short %>
+              </p>
+            </div>
+
+            <span class="material-symbols-outlined shrink-0 text-gray-300">
+              chevron_right
+            </span>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="rounded-2xl bg-white px-6 py-12 text-center shadow-sm">
+      <span class="material-symbols-outlined text-5xl text-gray-300">
+        notifications_none
+      </span>
+
+      <p class="mt-4 font-bold text-gray-600">
+        通知はまだありません
+      </p>
+
+      <p class="mt-2 text-sm text-gray-400">
+        予定に関する通知が届くと、ここに表示されます
+      </p>
+    </div>
+  <% end %>
+</main>

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -1,7 +1,7 @@
 <%= render "layouts/app_navigation",
            back_path: watchlists_path %>
 
-<div class="hidden md:block w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4">
+<div class="hidden md:block w-full max-w-4xl mx-auto px-6 pt-6">
   <%= link_to watchlists_path,
               class: "inline-flex items-center gap-1
                       text-sm font-bold text-primary

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   end
 
   resources :watchlists, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+  resources :notifications, only: [:index, :show]
   resource :settings, only: [:show]
   
   resources :url_parsers, only: [] do

--- a/db/migrate/20260804132500_create_notifications.rb
+++ b/db/migrate/20260804132500_create_notifications.rb
@@ -1,0 +1,15 @@
+class CreateNotifications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :watchlist, null: false, foreign_key: true
+
+      t.integer :notification_type, null: false
+      t.string :title, null: false
+      t.text :message, null: false
+      t.datetime :read_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_01_023643) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_04_132500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,19 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_01_023643) do
     t.datetime "updated_at", null: false
     t.index ["watchlist_id", "channel", "notification_type"], name: "idx_on_watchlist_id_channel_notification_type_e10fc11b38", unique: true
     t.index ["watchlist_id"], name: "index_notification_deliveries_on_watchlist_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "watchlist_id", null: false
+    t.integer "notification_type", null: false
+    t.string "title", null: false
+    t.text "message", null: false
+    t.datetime "read_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_notifications_on_user_id"
+    t.index ["watchlist_id"], name: "index_notifications_on_watchlist_id"
   end
 
   create_table "social_accounts", force: :cascade do |t|
@@ -67,6 +80,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_01_023643) do
   end
 
   add_foreign_key "notification_deliveries", "watchlists"
+  add_foreign_key "notifications", "users"
+  add_foreign_key "notifications", "watchlists"
   add_foreign_key "social_accounts", "users"
   add_foreign_key "watchlists", "users"
 end

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class NotificationsControllerTest < ActionDispatch::IntegrationTest
+  test 'should get index' do
+    get notifications_index_url
+    assert_response :success
+  end
+
+  test 'should get show' do
+    get notifications_show_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/notifications.yml
+++ b/test/fixtures/notifications.yml
@@ -1,0 +1,17 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  watchlist: one
+  notification_type: 1
+  title: MyString
+  message: MyText
+  read_at: 2026-08-04 22:25:00
+
+two:
+  user: two
+  watchlist: two
+  notification_type: 1
+  title: MyString
+  message: MyText
+  read_at: 2026-08-04 22:25:00

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class NotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

アプリ内通知機能を実装しました。
通知一覧・未読管理・通知バッジを追加し、メール・LINE通知と連携するようにしました。

## 背景

通知履歴をアプリ内でも確認できるようにし、メールやLINEを見逃した場合でもFanPocket内で通知内容を確認できるようにするため。

（closes: #83）

## 変更内容

- Notificationモデルを追加
- アプリ内通知作成用の `InAppNotificationService` を実装
- 通知一覧画面を実装
- 通知詳細を予定詳細画面へリダイレクトするよう変更
- 通知クリック時に既読化する処理を実装
- ヘッダーに通知ベル・未読件数バッジを追加
- 通知画面表示中はベルアイコンを塗りつぶし表示に変更
- MorningNotificationService にアプリ内通知作成処理を追加
- NightNotificationService にアプリ内通知作成処理を追加
- RealtimeLineNotificationService にアプリ内通知作成処理を追加
- Internal::NotificationsController からリアルタイムLINE通知を実行するよう修正
- PC表示の戻るリンク位置を調整

## 確認方法

- 通知一覧画面が表示されること
- 通知をクリックすると予定詳細画面へ遷移すること
- 通知を開くと既読になり、未読件数バッジが更新されること
- 朝通知でメール・アプリ内通知が作成されること
- 夜通知でメール・アプリ内通知が作成されること
- 開始10分前LINE通知でLINE・アプリ内通知が作成されること
- 締切3時間前LINE通知でLINE・アプリ内通知が作成されること
- NotificationDelivery により重複送信されないこと
- 本番環境（Render）でメール・LINE・アプリ内通知の動作を確認

## 影響範囲

- 通知機能
- メール通知
- LINE通知
- ヘッダー
- 通知一覧画面
- 予定詳細画面

## スクリーンショット
<img width="1919" height="997" alt="image" src="https://github.com/user-attachments/assets/9f0b7ed6-d773-4f56-af33-0a428cd81292" />

## 補足

- 通知送信後にアプリ内通知も同時作成する構成とした。
- 本番確認時にリアルタイムLINE通知が実行されない不具合を確認し、`Internal::NotificationsController` から `NotificationService.send_realtime_line_notifications` を呼び出すよう修正した。