### PR TITLE
通知設定を各通知処理に反映

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -3,5 +3,30 @@
 class SettingsController < ApplicationController
   before_action :authenticate_user!
 
-  def show; end
+  def show
+    @notification_setting = current_user.notification_setting
+  end
+
+  def update
+    @notification_setting = current_user.notification_setting
+
+    if @notification_setting.update(notification_setting_params)
+      redirect_to settings_path, notice: '通知設定を更新しました'
+    else
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def notification_setting_params
+    params.require(:notification_setting).permit(
+      :email_three_days_before,
+      :email_day_before,
+      :email_deadline_same_day,
+      :email_start_same_day,
+      :line_start_ten_minutes_before,
+      :line_deadline_three_hours_before
+    )
+  end
 end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class NotificationSetting < ApplicationRecord
+  belongs_to :user
+  has_one :notification_setting, dependent: :destroy
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,9 @@ class User < ApplicationRecord
   has_many :watchlists, dependent: :destroy
   has_many :social_accounts, dependent: :destroy
   has_many :notifications, dependent: :destroy
+  has_one :notification_setting, dependent: :destroy
 
+  after_create :create_notification_setting
   after_create_commit :send_welcome_email, if: -> { email.present? }
 
   def email_required?

--- a/app/services/morning_notification_service.rb
+++ b/app/services/morning_notification_service.rb
@@ -22,7 +22,6 @@ class MorningNotificationService
     def send_deadline_same_day_notification(watchlist)
       user = watchlist.user
       return unless user
-      return if delivered?(watchlist, :email, :deadline_same_day)
 
       deliver_deadline_same_day_notification(watchlist, user)
     rescue StandardError => e
@@ -33,8 +32,14 @@ class MorningNotificationService
       content = deadline_same_day_content(watchlist)
 
       create_deadline_same_day_notification(watchlist, content)
-      send_deadline_same_day_email(watchlist, user, content)
+      deliver_deadline_same_day_email(watchlist, user, content)
+    end
 
+    def deliver_deadline_same_day_email(watchlist, user, content)
+      return unless user.notification_setting&.email_deadline_same_day?
+      return if delivered?(watchlist, :email, :deadline_same_day)
+
+      send_deadline_same_day_email(watchlist, user, content)
       record_delivery(watchlist, :email, :deadline_same_day)
 
       log_success('当日締切', watchlist.id, user.email)
@@ -74,7 +79,6 @@ class MorningNotificationService
     def send_start_same_day_notification(watchlist)
       user = watchlist.user
       return unless user
-      return if delivered?(watchlist, :email, :start_same_day)
 
       deliver_start_same_day_notification(watchlist, user)
     rescue StandardError => e
@@ -85,8 +89,14 @@ class MorningNotificationService
       content = start_same_day_content(watchlist)
 
       create_start_same_day_notification(watchlist, content)
-      send_start_same_day_email(watchlist, user, content)
+      deliver_start_same_day_email(watchlist, user, content)
+    end
 
+    def deliver_start_same_day_email(watchlist, user, content)
+      return unless user.notification_setting&.email_start_same_day?
+      return if delivered?(watchlist, :email, :start_same_day)
+
+      send_start_same_day_email(watchlist, user, content)
       record_delivery(watchlist, :email, :start_same_day)
 
       log_success('当日開始', watchlist.id, user.email)

--- a/app/services/night_notification_service.rb
+++ b/app/services/night_notification_service.rb
@@ -15,16 +15,13 @@ class NightNotificationService
       targets = Watchlist.alert_three_days_prior.includes(:user)
 
       log_start('締切3日前', targets.count)
-      targets.find_each do |watchlist|
-        send_three_days_prior_notification(watchlist)
-      end
+      targets.find_each { |watchlist| send_three_days_prior_notification(watchlist) }
       log_finish('締切3日前')
     end
 
     def send_three_days_prior_notification(watchlist)
       user = watchlist.user
       return unless user
-      return if delivered?(watchlist, :email, :deadline_three_days_before)
 
       deliver_three_days_prior_notification(watchlist, user)
     rescue StandardError => e
@@ -35,6 +32,13 @@ class NightNotificationService
       content = three_days_prior_content(watchlist)
 
       create_three_days_prior_notification(watchlist, content)
+      deliver_three_days_prior_email(watchlist, user, content)
+    end
+
+    def deliver_three_days_prior_email(watchlist, user, content)
+      return unless user.notification_setting&.email_three_days_before?
+      return if delivered?(watchlist, :email, :deadline_three_days_before)
+
       send_three_days_prior_email(watchlist, user, content)
       record_delivery(watchlist, :email, :deadline_three_days_before)
 
@@ -68,16 +72,13 @@ class NightNotificationService
       targets = Watchlist.alert_day_before.includes(:user)
 
       log_start('締切前日', targets.count)
-      targets.find_each do |watchlist|
-        send_day_before_notification(watchlist)
-      end
+      targets.find_each { |watchlist| send_day_before_notification(watchlist) }
       log_finish('締切前日')
     end
 
     def send_day_before_notification(watchlist)
       user = watchlist.user
       return unless user
-      return if delivered?(watchlist, :email, :deadline_day_before)
 
       deliver_day_before_notification(watchlist, user)
     rescue StandardError => e
@@ -88,6 +89,13 @@ class NightNotificationService
       content = day_before_content(watchlist)
 
       create_day_before_notification(watchlist, content)
+      deliver_day_before_email(watchlist, user, content)
+    end
+
+    def deliver_day_before_email(watchlist, user, content)
+      return unless user.notification_setting&.email_day_before?
+      return if delivered?(watchlist, :email, :deadline_day_before)
+
       send_day_before_email(watchlist, user, content)
       record_delivery(watchlist, :email, :deadline_day_before)
 

--- a/app/services/realtime_line_notification_config.rb
+++ b/app/services/realtime_line_notification_config.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RealtimeLineNotificationConfig
+  CONFIGS = {
+    start_ten_minutes_before: {
+      log_type: '開始10分前LINE',
+      notification_type: :start_ten_minutes_before,
+      setting_key: :line_start_ten_minutes_before,
+      title: '開始まであと10分です',
+      message: "開始まであと10分です。\n\nまもなく始まります。\n詳細をご確認ください。"
+    },
+    deadline_three_hours_before: {
+      log_type: '締切3時間前LINE',
+      notification_type: :deadline_three_hours_before,
+      setting_key: :line_deadline_three_hours_before,
+      title: '締め切りまであと3時間です',
+      message: "締め切りまであと3時間です。\n\n大切な予定を見逃さないようご確認ください。"
+    }
+  }.freeze
+end

--- a/app/services/realtime_line_notification_service.rb
+++ b/app/services/realtime_line_notification_service.rb
@@ -11,49 +11,68 @@ class RealtimeLineNotificationService
 
     private
 
+    def line_notification_enabled?(user, setting_key)
+      user.notification_setting&.public_send("#{setting_key}?")
+    end
+
     def send_start_ten_minutes_before
       send_notifications(
         Watchlist.starting_within_ten_minutes,
-        log_type: '開始10分前LINE',
-        notification_type: :start_ten_minutes_before,
-        title: '開始まであと10分です',
-        message: start_ten_minutes_before_message
+        RealtimeLineNotificationConfig::CONFIGS[:start_ten_minutes_before]
       )
     end
 
     def send_deadline_three_hours_before
       send_notifications(
         Watchlist.deadline_three_hours_before,
-        log_type: '締切3時間前LINE',
-        notification_type: :deadline_three_hours_before,
-        title: '締め切りまであと3時間です',
-        message: deadline_three_hours_before_message
+        RealtimeLineNotificationConfig::CONFIGS[:deadline_three_hours_before]
       )
     end
 
-    def send_notifications(targets, log_type:, notification_type:, title:, message:)
+    def send_notifications(targets, config)
       targets = targets.includes(user: :social_accounts)
 
-      log_start(log_type, targets.count)
+      log_start(config[:log_type], targets.count)
 
       targets.find_each do |watchlist|
-        send_notification(watchlist, log_type:, notification_type:, title:, message:)
+        send_notification(watchlist, config)
       end
 
-      log_finish(log_type)
+      log_finish(config[:log_type])
     end
 
-    def send_notification(watchlist, log_type:, notification_type:, title:, message:)
-      create_in_app_notification(watchlist, notification_type, title, message)
+    def send_notification(watchlist, config)
+      create_in_app_notification(
+        watchlist,
+        config[:notification_type],
+        config[:title],
+        config[:message]
+      )
 
-      line_account = line_account_for(watchlist.user)
-
-      return unless line_account
-      return if delivered?(watchlist, :line, notification_type)
-
-      deliver_notification(watchlist, line_account, log_type:, notification_type:, message:)
+      deliver_line_notification(watchlist, config)
     rescue StandardError => e
-      log_error(log_type, watchlist.id, e)
+      log_error(config[:log_type], watchlist.id, e)
+    end
+
+    def deliver_line_notification(watchlist, config)
+      user = watchlist.user
+      line_account = line_account_for(user)
+
+      return unless line_deliverable?(watchlist, user, line_account, config)
+
+      deliver_notification(
+        watchlist,
+        line_account,
+        log_type: config[:log_type],
+        notification_type: config[:notification_type],
+        message: config[:message]
+      )
+    end
+
+    def line_deliverable?(watchlist, user, line_account, config)
+      line_account &&
+        line_notification_enabled?(user, config[:setting_key]) &&
+        !delivered?(watchlist, :line, config[:notification_type])
     end
 
     def deliver_notification(
@@ -87,14 +106,6 @@ class RealtimeLineNotificationService
 
     def notification_title(watchlist)
       "🌟 #{watchlist.display_title}"
-    end
-
-    def start_ten_minutes_before_message
-      "開始まであと10分です。\n\nまもなく始まります。\n詳細をご確認ください。"
-    end
-
-    def deadline_three_hours_before_message
-      "締め切りまであと3時間です。\n\n大切な予定を見逃さないようご確認ください。"
     end
 
     def watchlist_url(watchlist)

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -62,6 +62,82 @@
 
         </div>
       </section>
+    
+    <section>
+      <div class="flex items-center gap-2 mb-3 px-1">
+        <span class="material-symbols-outlined text-primary text-xl">notifications</span>
+        <h3 class="font-bold text-sm text-on-surface-variant">通知設定</h3>
+      </div>
+
+      <%= form_with model: @notification_setting,
+                    url: settings_path,
+                    method: :patch do |f| %>
+
+        <div class="bg-white rounded-xl shadow-sm overflow-hidden border border-base-200">
+          <div class="px-4 pt-4 pb-2">
+            <p class="text-xs font-semibold text-on-surface-variant">
+            メール通知
+            </p>
+            <p class="mt-1 text-xs text-gray-400">
+              予定を余裕を持って確認するための通知です
+            </p>
+          </div>
+
+          <div class="px-4">
+            <label class="flex items-center justify-between py-4 border-b border-gray-100">
+              <span class="text-primary font-medium">3日前</span>
+              <%= f.check_box :email_three_days_before, class: "toggle toggle-primary" %>
+            </label>
+
+            <label class="flex items-center justify-between py-4 border-b border-gray-100">
+              <span class="text-primary font-medium">前日</span>
+              <%= f.check_box :email_day_before, class: "toggle toggle-primary" %>
+            </label>
+
+            <label class="flex items-center justify-between py-4 border-b border-gray-100">
+              <span class="text-primary font-medium">締切当日</span>
+              <%= f.check_box :email_deadline_same_day, class: "toggle toggle-primary" %>
+            </label>
+
+            <label class="flex items-center justify-between py-4">
+              <span class="text-primary font-medium">開始当日</span>
+              <%= f.check_box :email_start_same_day, class: "toggle toggle-primary" %>
+            </label>
+          </div>
+
+          <div class="h-px bg-gray-100"></div>
+
+          <div class="px-4 pt-4 pb-2">
+            <p class="text-xs font-semibold text-on-surface-variant">
+              LINE通知
+            </p>
+            <p class="mt-1 text-xs text-gray-400">
+              行動が必要な直前にお知らせします
+            </p>
+          </div>
+
+          <div class="px-4">
+            <label class="flex items-center justify-between py-4 border-b border-gray-100">
+              <span class="text-primary font-medium">開始10分前</span>
+              <%= f.check_box :line_start_ten_minutes_before, class: "toggle toggle-primary" %>
+            </label>
+
+            <label class="flex items-center justify-between py-4">
+              <span class="text-primary font-medium">締切3時間前</span>
+              <%= f.check_box :line_deadline_three_hours_before, class: "toggle toggle-primary" %>
+            </label>
+          </div>
+
+          <div class="p-4 border-t border-gray-100">
+            <%= f.button type: "submit",
+                           class: "w-full bg-[#B6E0F3] text-[#2d6489] font-headline font-bold py-4 rounded-full puffy-shadow hover:brightness-105 transition-all active:scale-[0.97] flex items-center justify-center gap-3" do %>
+              <span class="material-symbols-outlined font-bold">save</span>
+                通知設定を保存
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </section>
 
     <section>
       <div class="flex items-center gap-2 mb-3 px-1">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
 
   resources :watchlists, only: [:index, :show, :new, :create, :edit, :update, :destroy]
   resources :notifications, only: [:index, :show]
-  resource :settings, only: [:show]
+  resource :settings, only: [:show, :update]
   
   resources :url_parsers, only: [] do
     collection do

--- a/db/migrate/20260807111506_create_notification_settings.rb
+++ b/db/migrate/20260807111506_create_notification_settings.rb
@@ -1,0 +1,15 @@
+class CreateNotificationSettings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :notification_settings do |t|
+      t.references :user, null: false, foreign_key: true, index: { unique: true }
+      t.boolean :email_three_days_before, null: false, default: true
+      t.boolean :email_day_before, null: false, default: true
+      t.boolean :email_deadline_same_day, null: false, default: true
+      t.boolean :email_start_same_day, null: false, default: true
+      t.boolean :line_start_ten_minutes_before, null: false, default: true
+      t.boolean :line_deadline_three_hours_before, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260808131207_backfill_notification_settings.rb
+++ b/db/migrate/20260808131207_backfill_notification_settings.rb
@@ -1,0 +1,18 @@
+class BackfillNotificationSettings < ActiveRecord::Migration[7.1]
+  def up
+    execute <<~SQL.squish
+      INSERT INTO notification_settings (user_id, created_at, updated_at)
+      SELECT users.id, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+      FROM users
+      WHERE NOT EXISTS (
+        SELECT 1
+        FROM notification_settings
+        WHERE notification_settings.user_id = users.id
+      )
+    SQL
+  end
+
+  def down
+    # バックフィルした設定だけを安全に特定できないため削除しない
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_04_132500) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_08_131207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,19 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_04_132500) do
     t.datetime "updated_at", null: false
     t.index ["watchlist_id", "channel", "notification_type"], name: "idx_on_watchlist_id_channel_notification_type_e10fc11b38", unique: true
     t.index ["watchlist_id"], name: "index_notification_deliveries_on_watchlist_id"
+  end
+
+  create_table "notification_settings", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.boolean "email_three_days_before", default: true, null: false
+    t.boolean "email_day_before", default: true, null: false
+    t.boolean "email_deadline_same_day", default: true, null: false
+    t.boolean "email_start_same_day", default: true, null: false
+    t.boolean "line_start_ten_minutes_before", default: true, null: false
+    t.boolean "line_deadline_three_hours_before", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_notification_settings_on_user_id", unique: true
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -80,6 +93,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_04_132500) do
   end
 
   add_foreign_key "notification_deliveries", "watchlists"
+  add_foreign_key "notification_settings", "users"
   add_foreign_key "notifications", "users"
   add_foreign_key "notifications", "watchlists"
   add_foreign_key "social_accounts", "users"

--- a/test/fixtures/notification_settings.yml
+++ b/test/fixtures/notification_settings.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  email_three_days_before: false
+  email_day_before: false
+  email_deadline_same_day: false
+  email_start_same_day: false
+  line_start_ten_minutes_before: false
+  line_deadline_three_hours_before: false
+
+two:
+  user: two
+  email_three_days_before: false
+  email_day_before: false
+  email_deadline_same_day: false
+  email_start_same_day: false
+  line_start_ten_minutes_before: false
+  line_deadline_three_hours_before: false

--- a/test/models/notification_setting_test.rb
+++ b/test/models/notification_setting_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class NotificationSettingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
ユーザーごとの通知設定を、メール・LINEの各通知処理に反映しました。
あわせて、既存ユーザーにも通知設定を作成するバックフィルを追加しました。

## 背景
通知設定画面でメール・LINE通知のON/OFFを変更しても、
実際の通知処理には設定が反映されていなかったため対応しました。
（closes: #92）

## 変更内容
- メール通知に通知設定のON/OFF判定を追加
  - 締切3日前
  - 締切前日
  - 締切当日
  - 開始当日
- LINE通知に通知設定のON/OFF判定を追加
  - 開始10分前
  - 締切3時間前
- メール・LINEがOFFの場合でもアプリ内通知は作成されるように処理を分離
- 既存ユーザーに `NotificationSetting` を作成するバックフィルマイグレーションを追加
- LINE通知の設定を `RealtimeLineNotificationConfig` に切り出し
- 通知サービスをリファクタリング

## 確認方法
- 通知設定をすべてOFFにした状態で通知処理を実行
  - アプリ内通知が作成されることを確認
  - メールが送信されないことを確認
  - LINEが送信されないことを確認
- メール通知をONにして、メールが送信されることを確認
- LINE通知をONにして、LINEが送信されることを確認
- バックフィル実行後、`User.count` と `NotificationSetting.count` が一致することを確認
- RuboCopが通ることを確認

## 影響範囲
- 通知設定
- メール通知
- LINE通知
- アプリ内通知
- 既存ユーザーの通知設定データ

## スクリーンショット
<img width="922" height="816" alt="image" src="https://github.com/user-attachments/assets/0e901ca6-4edc-4d7e-a7b8-ab40e21c586e" />

## 補足
通知媒体の設定をOFFにしていても、アプリ内通知は通知履歴として作成されます。

既存ユーザーは `after_create` による `NotificationSetting` の自動作成対象外のため、
バックフィルマイグレーションで不足している通知設定を作成しています。