### PR TITLE
マイページからのパスワード変更機能を実装

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Users
+  class RegistrationsController < Devise::RegistrationsController
+    protected
+
+    def update_resource(resource, params)
+      if params[:password].blank?
+        resource.errors.add(:password, :blank)
+        false
+      else
+        resource.update_with_password(params)
+      end
+    end
+
+    def after_update_path_for(_resource)
+      settings_path
+    end
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,42 +1,123 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<%= render "layouts/app_navigation" %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<main class="w-full max-w-2xl mx-auto px-4 sm:px-6 mt-10 md:mt-14 pb-28 md:pb-12">
+  <div class="mb-8 md:mb-10 text-center">
+    <div class="inline-flex items-center justify-center w-16 h-16 bg-[#e0f2fe]/30 rounded-3xl mb-4">
+      <span class="material-symbols-outlined text-primary text-3xl">lock_reset</span>
+    </div>
+    <h2 class="font-headline font-extrabold text-4xl tracking-tight text-primary">
+      パスワード変更
+    </h2>
 
-  <div class="field">
-    <p><%= f.label :email %></p>
-    <p><%= f.email_field :email, autofocus: true, autocomplete: "email" %></p>
+    <p class="mt-2 text-sm font-medium text-gray-500 leading-relaxed px-4">
+      現在のパスワードを確認して、新しいパスワードへ変更します<br>
+      <span class="text-sm text-gray-400">
+        メールアドレスとパスワードで登録した方のみ変更できます
+      </span>
+    </p>
   </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <%= form_for(resource,
+               as: resource_name,
+               url: registration_path(resource_name),
+               html: { method: :put }) do |f| %>
+
+    <%= render "devise/shared/error_messages", resource: resource %>
+
+    <div class="space-y-5">
+      <div>
+        <%= f.label :current_password,
+                    "現在のパスワード",
+                    class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
+
+        <div class="relative group mt-2" data-controller="password-toggle">
+          <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
+            <span class="material-symbols-outlined text-[20px]">lock</span>
+          </div>
+
+          <%= f.password_field :current_password,
+                               autocomplete: "current-password",
+                               placeholder: "••••••••",
+                               class: "w-full h-14 pl-14 pr-14 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
+                               data: { password_toggle_target: "input" } %>
+
+          <button type="button"
+                  class="absolute inset-y-0 right-0 pr-6 flex items-center text-gray-400 hover:text-primary transition-colors"
+                  data-action="password-toggle#toggle">
+            <span class="material-symbols-outlined text-[20px]"
+                  data-password-toggle-target="icon">
+              visibility
+            </span>
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <%= f.label :password,
+                    "新しいパスワード",
+                    class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
+
+        <div class="relative group mt-2" data-controller="password-toggle">
+          <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
+            <span class="material-symbols-outlined text-[20px]">lock</span>
+          </div>
+
+          <%= f.password_field :password,
+                               autocomplete: "new-password",
+                               placeholder: "••••••••",
+                               class: "w-full h-14 pl-14 pr-14 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
+                               data: { password_toggle_target: "input" } %>
+
+          <button type="button"
+                  class="absolute inset-y-0 right-0 pr-6 flex items-center text-gray-400 hover:text-primary transition-colors"
+                  data-action="password-toggle#toggle">
+            <span class="material-symbols-outlined text-[20px]"
+                  data-password-toggle-target="icon">
+              visibility
+            </span>
+          </button>
+        </div>
+
+        <% if @minimum_password_length %>
+          <p class="mt-2 px-6 text-xs text-gray-400">
+            <%= @minimum_password_length %>文字以上で入力してください
+          </p>
+        <% end %>
+      </div>
+
+      <div>
+        <%= f.label :password_confirmation,
+                    "新しいパスワード（確認）",
+                    class: "text-gray-500 text-[11px] font-bold px-6 tracking-widest uppercase opacity-60" %>
+
+        <div class="relative group mt-2" data-controller="password-toggle">
+          <div class="absolute inset-y-0 left-0 pl-6 flex items-center pointer-events-none text-[#8BBEE8] group-focus-within:text-primary transition-colors">
+            <span class="material-symbols-outlined text-[20px]">lock</span>
+          </div>
+
+          <%= f.password_field :password_confirmation,
+                               autocomplete: "new-password",
+                               placeholder: "••••••••",
+                               class: "w-full h-14 pl-14 pr-14 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
+                               data: { password_toggle_target: "input" } %>
+
+          <button type="button"
+                  class="absolute inset-y-0 right-0 pr-6 flex items-center text-gray-400 hover:text-primary transition-colors"
+                  data-action="password-toggle#toggle">
+            <span class="material-symbols-outlined text-[20px]"
+                  data-password-toggle-target="icon">
+              visibility
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="mt-6">
+      <%= f.submit "パスワードを変更する",
+                   class: "w-full bg-[#B6E0F3] text-[#2d6489] font-headline font-bold py-4 rounded-full puffy-shadow hover:brightness-105 transition-all active:scale-[0.97] cursor-pointer" %>
+    </div>
   <% end %>
+</main>
 
-  <div class="field">
-    <p><%= f.label :password %> <i>(leave blank if you don't want to change it)</i></p>
-    <p><%= f.password_field :password, autocomplete: "new-password" %></p>
-    <% if @minimum_password_length %>
-      <p><em><%= @minimum_password_length %> characters minimum</em></p>
-    <% end %>
-  </div>
-
-  <div class="field">
-    <p><%= f.label :password_confirmation %></p>
-    <p><%= f.password_field :password_confirmation, autocomplete: "new-password" %></p>
-  </div>
-
-  <div class="field">
-    <p><%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i></p>
-    <p><%= f.password_field :current_password, autocomplete: "current-password" %></p>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+<%= render "layouts/footer" %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -30,16 +30,16 @@
             <span class="material-symbols-outlined text-lg shrink-0">chevron_right</span>
           </div>
         </button>
-        <div class="h-px mx-4 bg-gray-100"></div>
-        <button class="w-full min-h-11 flex items-center justify-between p-4 hover:bg-gray-50 active:bg-gray-50 transition-colors text-left" disabled>
-          <div class="flex items-center gap-2">
-            <span class="material-symbols-outlined text-primary/50 text-xl">lock</span>
-            <span class="text-primary font-medium">パスワードの変更</span>
-          </div>
-          <div class="flex items-center gap-2 text-on-surface-variant">
+        <div class="border-b border-gray-100 mx-4">
+          <%= link_to edit_user_registration_path,
+                      class: "block w-full min-h-11 flex items-center justify-between py-4 hover:bg-gray-50 active:bg-gray-50 transition-colors text-left" do %>
+            <div class="flex items-center gap-2">
+              <span class="material-symbols-outlined text-primary/50 text-xl">lock</span>
+              <span class="text-primary font-medium">パスワードを変更する</span>
+            </div>
             <span class="material-symbols-outlined text-on-surface-variant text-lg">chevron_right</span>
-          </div>
-        </button>
+          <% end %>
+        </div>
 
         <div class="h-px mx-4 bg-gray-100"></div>
           <div class="px-4 pt-4 pb-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: 'users/sessions',
+    registrations: 'users/registrations',
     omniauth_callbacks: "users/omniauth_callbacks"
   }
 


### PR DESCRIPTION
## 概要

ログイン中のユーザーが、設定画面から現在のパスワードを確認した上で新しいパスワードへ変更できる機能を実装しました。
Deviseの`RegistrationsController`を継承し、既存の認証機能を活用しています。

## 背景

ログイン後にユーザー自身がパスワードを変更するための動線がなかったため、
設定画面から安全にパスワードを変更できるようにしました。

closes #75

## 変更内容

- 設定画面の「パスワードを変更する」からパスワード変更画面へ遷移できるように変更
- Deviseの`RegistrationsController`を継承した`Users::RegistrationsController`を追加
- パスワード変更後のリダイレクト先を設定画面に変更
- 新しいパスワードが未入力の場合は更新されないように制御
- Devise標準の登録情報編集画面をパスワード変更用のUIに変更
- 現在のパスワード、新しいパスワード、確認用パスワードの入力欄を実装
- パスワード表示・非表示の切り替えに既存の`password-toggle`を利用
- SNS登録ユーザー向けに「メールアドレスとパスワードで登録した方のみ変更できます」の案内を追加
- パスワード変更成功後はDevise標準のFlashメッセージを表示

## 確認方法

- 設定画面の「パスワードを変更する」から変更画面へ遷移できることを確認
- 現在のパスワード・新しいパスワード・確認用パスワードを正しく入力し、変更できることを確認
- パスワード変更後に設定画面へリダイレクトされることを確認
- 更新成功時に「アカウント情報を変更しました。」とFlashメッセージが表示されることを確認
- 新しいパスワードが未入力の場合、更新されずエラーが表示されることを確認
- 現在のパスワードが誤っている場合、更新されないことを確認
- 新しいパスワードと確認用パスワードが一致しない場合、更新されないことを確認
- RuboCopが通ることを確認

## 影響範囲

- 設定画面
- Deviseのユーザー登録情報編集画面
- ログイン中ユーザーのパスワード変更処理
- Google・LINEのログイン・アカウント連携処理には変更なし
- パスワードリセット機能には変更なし

## スクリーンショット

-  パスワード変更画面
<img width="1919" height="988" alt="image" src="https://github.com/user-attachments/assets/5699868f-222a-4c18-b6d3-ab2700052107" />


## 補足

Google・LINEなどSNS経由で新規登録したユーザーは、FanPocket内部でランダムなパスワードが生成されており、現在のパスワードを把握していません。
そのため、パスワード変更画面に「メールアドレスとパスワードで登録した方のみ変更できます」と案内を表示しています。

SNS登録ユーザーがメールアドレス・パスワードによるログインも利用できるようにする機能については、必要に応じて別Issueで検討します。

また、成功時のFlash「アカウント情報を変更しました。」は、今後メールアドレス変更などでもDeviseの登録情報更新処理を利用する可能性を考慮し、汎用的な文言のままとしています。