### PR TITLE
タグ機能とタグ検索を実装

### DIFF
--- a/app/controllers/watchlists_controller.rb
+++ b/app/controllers/watchlists_controller.rb
@@ -5,11 +5,15 @@ class WatchlistsController < ApplicationController
   before_action :set_watchlist, only: %i[show edit update]
 
   def index
+    watchlists = current_user.watchlists
+
+    watchlists = watchlists.tagged_with(params[:tag]) if params[:tag].present?
+
     # 1. 「これからの予定」
-    @future_watchlists = current_user.watchlists.upcoming
+    @future_watchlists = watchlists.upcoming
 
     # 2. 「これまでの足跡」
-    @past_watchlists = current_user.watchlists.past
+    @past_watchlists = watchlists.past
   end
 
   def show; end
@@ -20,17 +24,22 @@ class WatchlistsController < ApplicationController
 
   def create
     @watchlist = current_user.watchlists.build(watchlist_params)
+
     if @watchlist.save
+      @watchlist.save_tags
       redirect_to watchlists_path, notice: '新しい予定を登録しました'
     else
       render :new, status: :unprocessable_entity
     end
   end
 
-  def edit; end
+  def edit
+    @watchlist.tag_names = @watchlist.tags.pluck(:name).join(', ')
+  end
 
   def update
     if @watchlist.update(watchlist_params)
+      @watchlist.save_tags
       redirect_to watchlist_path(@watchlist), notice: '更新しました'
     else
       render :edit, status: :unprocessable_entity
@@ -64,16 +73,19 @@ class WatchlistsController < ApplicationController
     redirect_to watchlists_path, alert: '指定されたページは見つかりません'
   end
 
+  WATCHLIST_PARAMS = %i[
+    title
+    memo
+    url
+    start_at
+    end_at
+    is_done
+    reception_type
+    reception_detail
+    tag_names
+  ].freeze
+
   def watchlist_params
-    params.require(:watchlist).permit(
-      :title,
-      :memo,
-      :url,
-      :start_at,
-      :end_at,
-      :is_done,
-      :reception_type,
-      :reception_detail
-    )
+    params.require(:watchlist).permit(*WATCHLIST_PARAMS)
   end
 end

--- a/app/models/concerns/watchlist_notifiable.rb
+++ b/app/models/concerns/watchlist_notifiable.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module WatchlistNotifiable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :alert_three_days_prior, -> { where(is_done: false, end_at: 3.days.from_now.all_day) }
+    scope :alert_day_before, -> { where(is_done: false, end_at: 1.day.from_now.all_day) }
+    scope :alert_same_day, -> { where(is_done: false, end_at: Time.current.all_day) }
+    scope :starting_today, -> { where(start_at: Time.current.all_day, is_done: false) }
+
+    scope :starting_within_ten_minutes, lambda { |current_time = Time.current|
+      where(is_done: false)
+        .where('start_at > ? AND start_at <= ?', current_time, current_time + 10.minutes)
+    }
+
+    scope :deadline_three_hours_before, lambda { |current_time = Time.current|
+      notification_limit = current_time + 3.hours
+
+      where(is_done: false)
+        .where(
+          'end_at > ? AND end_at <= ?',
+          notification_limit - 10.minutes,
+          notification_limit
+        )
+    }
+  end
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Tag < ApplicationRecord
+  belongs_to :user
+
+  has_many :watchlist_tags, dependent: :destroy
+  has_many :watchlists, through: :watchlist_tags
+
+  validates :name, presence: true, uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
   has_many :watchlists, dependent: :destroy
   has_many :social_accounts, dependent: :destroy
   has_many :notifications, dependent: :destroy
+  has_many :tags, dependent: :destroy
   has_one :notification_setting, dependent: :destroy
 
   after_create :create_notification_setting

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 class Watchlist < ApplicationRecord
+  include WatchlistNotifiable
+  attr_accessor :tag_names
+
   belongs_to :user
 
   has_many :notification_deliveries, dependent: :destroy
   has_many :notifications, dependent: :destroy
+  has_many :watchlist_tags, dependent: :destroy
+  has_many :tags, through: :watchlist_tags
 
   before_validation :set_end_at_to_end_of_day, if: :end_at_time_blank?
 
@@ -16,6 +21,8 @@ class Watchlist < ApplicationRecord
 
   validate :end_at_must_be_future, on: :create
   validate :end_at_must_be_after_start_at
+  
+  validates :reception_detail, length: { maximum: 20 }, allow_blank: true
 
   enum :reception_type, {
     not_set: 0,     # 指定なし
@@ -24,7 +31,6 @@ class Watchlist < ApplicationRecord
     made_to_order: 3, # 受注販売
     general: 4 # 一般販売
   }, default: :not_set
-  validates :reception_detail, length: { maximum: 20 }, allow_blank: true
 
   def reception_type_label
     I18n.t(
@@ -44,6 +50,20 @@ class Watchlist < ApplicationRecord
 
   def display_title
     "#{reception_label_text}#{title}"
+  end
+
+  def save_tags
+    names = tag_names
+            .to_s
+            .split(/[,，、]/)
+            .map(&:strip)
+            .reject(&:blank?)
+
+    selected_tags = names.map do |name|
+      user.tags.find_or_create_by!(name: name)
+    end
+
+    self.tags = selected_tags
   end
 
   # 「これからの予定」を取得するスコープ
@@ -67,42 +87,13 @@ class Watchlist < ApplicationRecord
       .order(end_at: :desc)
   }
 
-  # 3日前通知用
-  scope :alert_three_days_prior, lambda {
-    where(is_done: false, end_at: 3.days.from_now.all_day)
-  }
-
-  # 前日通知用
-  scope :alert_day_before, lambda {
-    where(is_done: false, end_at: 1.day.from_now.all_day)
-  }
-
-  # 当日通知用
-  scope :alert_same_day, lambda {
-    where(is_done: false, end_at: Time.current.all_day)
-  }
-
-  # 今日が開始日かつ未完了のデータを取得
-  scope :starting_today, lambda {
-    where(start_at: Time.current.all_day, is_done: false)
-  }
-
-  # 開始10分前LINE通知用
-  scope :starting_within_ten_minutes, lambda { |current_time = Time.current|
-    where(is_done: false)
-      .where('start_at > ? AND start_at <= ?', current_time, current_time + 10.minutes)
-  }
-
-  # 締切3時間前LINE通知用
-  scope :deadline_three_hours_before, lambda { |current_time = Time.current|
-    notification_limit = current_time + 3.hours
-
-    where(is_done: false)
-      .where(
-        'end_at > ? AND end_at <= ?',
-        notification_limit - 10.minutes,
-        notification_limit
-      )
+  scope :tagged_with, lambda { |keyword|
+    where(
+      id: WatchlistTag
+          .joins(:tag)
+          .where('tags.name ILIKE ?', "%#{keyword}%")
+          .select(:watchlist_id)
+    )
   }
 
   private

--- a/app/models/watchlist_tag.rb
+++ b/app/models/watchlist_tag.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class WatchlistTag < ApplicationRecord
+  belongs_to :watchlist
+  belongs_to :tag
+
+  validates :tag_id, uniqueness: { scope: :watchlist_id }
+end

--- a/app/views/watchlists/_form.html.erb
+++ b/app/views/watchlists/_form.html.erb
@@ -39,8 +39,11 @@
   </div>
 
   <div class="space-y-3">
-    <%= f.label :reception_type, "種別",
-      class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" %>
+    <%= f.label :reception_type,
+      class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
+      <span class="material-symbols-outlined text-lg">category</span>
+      種別
+    <% end %>
 
     <div class="flex flex-wrap gap-3">
       <label class="flex items-center gap-2 text-sm">
@@ -72,7 +75,7 @@
 
   <div class="space-y-3">
     <%= f.label :reception_detail, "種別詳細",
-      class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" %>
+      class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1 ml-8" %>
 
     <%= f.text_field :reception_detail,
       class: "w-full h-14 px-6 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
@@ -80,14 +83,18 @@
   </div>
 
   <div class="space-y-3">
-    <%= f.label :title, "タイトル", class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" %>
-    
+    <%= f.label :title,
+      class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
+      <span class="material-symbols-outlined text-lg">title</span>
+      タイトル
+    <% end %>
+
     <%= f.text_field :title, 
           data: { 
             watchlist_form_target: "titleInput",
             action: "input->watchlist-form#checkTitle"
           }, 
-          class: "w-full h-14 px-6 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:title].any?}", placeholder: "タイトルを入力" %>
+          class: "w-full h-14 px-6 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:title].any?}", placeholder: "グッズ予約、ライブ名など" %>
 
     <% if watchlist.errors[:title].any? %>
       <p data-watchlist-form-target="titleErrorMessage" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
@@ -97,19 +104,35 @@
     <% end %>
   </div>
 
+  <div class="space-y-3">
+  <%= f.label :tag_names,
+    class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
+    <span class="material-symbols-outlined text-lg">tag</span>
+    タグ
+  <% end %>
+
+  <%= f.text_field :tag_names,
+    class: "w-full h-14 px-6 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300",
+    placeholder: "アーティスト名, ライブ, グッズなど" %>
+
+  <p class="text-xs text-gray-400 px-1">
+    複数入力する場合は「,」「、」などで区切ってください
+  </p>
+</div>
+
   <div class="grid grid-cols-1 gap-8 mt-8">
     <div class="space-y-3">
       <%= f.label :start_at, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
         <span class="material-symbols-outlined text-lg">calendar_today</span>開始日時
       <% end %>
-      <%= f.text_field :start_at, data: { controller: "flatpickr", watchlist_form_target: "startAtInput" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:start_at].any?}", placeholder: "年/月/日 --:--" %>
+      <%= f.text_field :start_at, data: { controller: "flatpickr", watchlist_form_target: "startAtInput" }, class: "datepicker w-full h-14 px-6 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:start_at].any?}", placeholder: "年/月/日 --:--" %>
     </div>
 
     <div class="space-y-3">
       <%= f.label :end_at, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
         <span class="material-symbols-outlined text-lg">timer</span>締切日時
       <% end %>
-      <%= f.text_field :end_at, data: { controller: "flatpickr", watchlist_form_target: "endAtInput" }, class: "datepicker w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:end_at].any?}", placeholder: "年/月/日 --:--" %>
+      <%= f.text_field :end_at, data: { controller: "flatpickr", watchlist_form_target: "endAtInput" }, class: "datepicker w-full h-14 px-6 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:end_at].any?}", placeholder: "年/月/日 --:--" %>
       
       <% if watchlist.errors[:end_at].any? %>
         <p data-watchlist-form-target="endAtRealtimeError" class="text-error text-xs font-semibold pl-4 flex items-center gap-1">
@@ -125,7 +148,7 @@
     <%= f.label :memo, class: "font-headline font-bold text-xs uppercase tracking-widest text-primary/60 flex items-center gap-2 px-1" do %>
       <span class="material-symbols-outlined text-lg">description</span>メモ
     <% end %>
-    <%= f.text_area :memo, class: "w-full min-h-[120px] pl-12 pr-8 py-5 bg-[#f0f4f8] border-none rounded-[32px] shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-400/60 leading-relaxed", placeholder: "持ち物、連番相手の連絡先など..." %>
+    <%= f.text_area :memo, class: "w-full min-h-[120px] px-6 py-5 bg-[#f0f4f8] border-none rounded-[32px] shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-400/60 leading-relaxed", placeholder: "持ち物、連番相手の連絡先など..." %>
   </div>
 
   <div class="form-control mb-4 pb-4">

--- a/app/views/watchlists/_watchlist_card.html.erb
+++ b/app/views/watchlists/_watchlist_card.html.erb
@@ -57,6 +57,17 @@
                    break-words">
           <%= watchlist.title %>
         </h3>
+
+        <% if watchlist.tags.any? %>
+          <div class="mt-1 flex flex-wrap gap-x-2 gap-y-1">
+            <% watchlist.tags.each do |tag| %>
+              <%= link_to watchlists_path(tag_id: tag.id),
+                          class: "text-sm font-medium text-primary/70 hover:opacity-70" do %>
+                #<%= tag.name %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
       </div>
 
       <%# 右側：ステータス %>

--- a/app/views/watchlists/edit.html.erb
+++ b/app/views/watchlists/edit.html.erb
@@ -1,10 +1,10 @@
 <%= render "layouts/app_navigation",
            back_path: watchlist_path %>
 
-<div class="hidden md:block w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4">
-  <%= link_to watchlist_path(@watchlist),
+<div class="hidden md:block w-full max-w-4xl mx-auto px-6 pt-6">
+  <%= link_to watchlists_path,
               class: "inline-flex items-center gap-1
-                      text-base font-bold text-primary
+                      text-sm font-bold text-primary
                       hover:opacity-70 transition-opacity" do %>
     <span class="material-symbols-outlined text-xl">
       arrow_back

--- a/app/views/watchlists/index.html.erb
+++ b/app/views/watchlists/index.html.erb
@@ -7,49 +7,133 @@
 </div>
 
 <main class="w-full max-w-3xl mx-auto px-4 sm:px-6 mt-10 md:mt-14 pb-40 md:pb-32">
-  <%# これからの予定セクション %>
-  <div class="mb-6">
-    <% if @future_watchlists.any? %>
-      <div class="space-y-4 md:space-y-5">
-        <% @future_watchlists.each do |watchlist| %>
-          <%= render "watchlist_card", watchlist: watchlist, is_past: false %>
-        <% end %>
-      </div>
-    <% else %>
-      <div class="flex flex-col items-center justify-center
-                  px-5 py-10 md:py-12
-                  text-center bg-white/30 rounded-3xl
-                  border border-dashed border-[#4f5052]">
-        <span class="material-symbols-outlined text-4xl text-[#B6E0F3] mb-2">
-          auto_awesome
+  <div class="mb-8">
+    <%= form_with url: watchlists_path,
+                  method: :get,
+                  local: true,
+                  class: "flex items-center gap-2" do |f| %>
+
+      <div class="relative flex-1">
+        <span class="material-symbols-outlined
+                     absolute left-5 top-1/2 -translate-y-1/2
+                     text-primary/50">
+          search
         </span>
 
-        <p class="text-[#4f5052] text-sm sm:text-base font-headline font-bold leading-relaxed">
-          お気に入りの予定を、ポケットに入れて持ち歩こう。
+        <%= f.text_field :tag,
+              value: params[:tag],
+              class: "w-full h-14 pl-14 pr-6
+                      bg-white border-none rounded-full shadow-sm
+                      focus:outline-none focus:ring-2 focus:ring-primary
+                      text-gray-700 font-medium
+                      placeholder:text-gray-300",
+              placeholder: "タグを検索" %>
+      </div>
+
+      <%= f.submit "検索",
+            class: "h-14 px-5
+                    rounded-full
+                    bg-[#B6E0F3] text-[#2d6489]
+                    font-bold shadow-sm
+                    hover:brightness-105
+                    active:scale-95
+                    transition-all" %>
+    <% end %>
+
+    <% if params[:tag].present? %>
+      <div class="mt-3 mb-6 flex items-center gap-3 px-2">
+        <p class="text-sm text-primary/70 font-medium">
+          「<%= params[:tag] %>」で絞り込み中
         </p>
+
+        <%= link_to watchlists_path,
+            class: "inline-flex items-center gap-1
+                    text-xs font-bold text-primary
+                    bg-[#B6E0F3]/40
+                    px-3 py-1.5 rounded-full
+                    hover:bg-[#B6E0F3]/70
+                    active:scale-95
+                    transition-all" do %>
+          <span class="material-symbols-outlined text-sm">
+            close
+          </span>
+          絞り込みを解除
+        <% end %>
       </div>
     <% end %>
   </div>
 
-  <%# 終わった予定セクション %>
-  <% if @past_watchlists.any? %>
-    <section class="mt-10 md:mt-12 mb-6">
-      <div class="divider font-headline text-sm opacity-40 gap-1">
-        <span>これまでの足跡</span>
+    <%# 検索結果が未来にも過去にもない場合 %>
+  <% if params[:tag].present? &&
+        @future_watchlists.empty? &&
+        @past_watchlists.empty? %>
 
-        <span
-          class="material-symbols-outlined text-lg"
-          style="font-variation-settings: 'opsz' 20, 'wght' 300;">
-          footprint
-        </span>
+    <div class="flex flex-col items-center justify-center
+                px-5 py-10 md:py-12
+                text-center bg-white/30 rounded-3xl
+                border border-dashed border-[#4f5052]">
+
+      <span class="material-symbols-outlined text-4xl text-[#B6E0F3] mb-2">
+        search_off
+      </span>
+
+      <p class="text-[#4f5052] text-sm sm:text-base font-headline font-bold leading-relaxed">
+        「<%= params[:tag] %>」に一致する予定はありません
+      </p>
+    </div>
+
+  <% else %>
+
+    <%# これからの予定セクション %>
+    <% if @future_watchlists.any? %>
+      <div class="mb-6">
+        <div class="space-y-4 md:space-y-5">
+          <% @future_watchlists.each do |watchlist| %>
+            <%= render "watchlist_card", watchlist: watchlist, is_past: false %>
+          <% end %>
+        </div>
       </div>
 
-      <div class="space-y-4 md:space-y-5">
-        <% @past_watchlists.each do |watchlist| %>
-          <%= render "watchlist_card", watchlist: watchlist, is_past: true %>
-        <% end %>
+    <% elsif params[:tag].blank? %>
+      <%# 検索していない＆これからの予定がない場合 %>
+      <div class="mb-6">
+        <div class="flex flex-col items-center justify-center
+                    px-5 py-10 md:py-12
+                    text-center bg-white/30 rounded-3xl
+                    border border-dashed border-[#4f5052]">
+
+          <span class="material-symbols-outlined text-4xl text-[#B6E0F3] mb-2">
+            auto_awesome
+          </span>
+
+          <p class="text-[#4f5052] text-sm sm:text-base font-headline font-bold leading-relaxed">
+            お気に入りの予定を、ポケットに入れて持ち歩こう。
+          </p>
+        </div>
       </div>
-    </section>
+    <% end %>
+
+    <%# 終わった予定セクション %>
+    <% if @past_watchlists.any? %>
+      <section class="mt-10 md:mt-12 mb-6">
+        <div class="divider font-headline text-sm opacity-40 gap-1">
+          <span>これまでの足跡</span>
+
+          <span
+            class="material-symbols-outlined text-lg"
+            style="font-variation-settings: 'opsz' 20, 'wght' 300;">
+            footprint
+          </span>
+        </div>
+
+        <div class="space-y-4 md:space-y-5">
+          <% @past_watchlists.each do |watchlist| %>
+            <%= render "watchlist_card", watchlist: watchlist, is_past: true %>
+          <% end %>
+        </div>
+      </section>
+    <% end %>
+
   <% end %>
 </main>
 

--- a/app/views/watchlists/new.html.erb
+++ b/app/views/watchlists/new.html.erb
@@ -3,10 +3,10 @@
   <%= render "layouts/app_navigation",
            back_path: watchlists_path %>
 
-  <div class="hidden md:block w-full max-w-3xl mx-auto px-4 sm:px-6 pt-4">
+  <div class="hidden md:block w-full max-w-4xl mx-auto px-6 pt-6">
     <%= link_to watchlists_path,
                 class: "inline-flex items-center gap-1
-                        text-base font-bold text-primary
+                        text-sm font-bold text-primary
                         hover:opacity-70 transition-opacity" do %>
       <span class="material-symbols-outlined text-xl">
         arrow_back

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -38,6 +38,16 @@
     <h2 class="font-headline font-extrabold text-3xl text-on-surface leading-tight tracking-tight relative z-10 break-words whitespace-normal">
       <%= @watchlist.title %>
     </h2>
+
+    <% if @watchlist.tags.any? %>
+      <div class="mt-3 flex flex-wrap gap-x-2 gap-y-1 relative z-10">
+        <% @watchlist.tags.each do |tag| %>
+          <span class="text-sm font-medium text-primary/70">
+            #<%= tag.name %>
+          </span>
+        <% end %>
+      </div>
+    <% end %>
   
     <div class="absolute pointer-events-none select-none z-0" style="bottom: 0; right: 0; width: 100%; height: 100%; overflow: hidden;">
       <span class="material-symbols-outlined" style="font-size: 160px; line-height: 1; position: absolute; bottom: -25px; right: -20px; opacity: 0.05; font-variation-settings: 'wght' 100;">

--- a/db/migrate/20260811080951_create_tags.rb
+++ b/db/migrate/20260811080951_create_tags.rb
@@ -1,0 +1,12 @@
+class CreateTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tags do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :tags, %i[user_id name], unique: true
+  end
+end

--- a/db/migrate/20260811091719_create_watchlist_tags.rb
+++ b/db/migrate/20260811091719_create_watchlist_tags.rb
@@ -1,0 +1,12 @@
+class CreateWatchlistTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :watchlist_tags do |t|
+      t.references :watchlist, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :watchlist_tags, %i[watchlist_id tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_08_131207) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_11_091719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -61,6 +61,15 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_08_131207) do
     t.index ["user_id"], name: "index_social_accounts_on_user_id"
   end
 
+  create_table "tags", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "name"], name: "index_tags_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_tags_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email"
     t.string "encrypted_password", default: "", null: false
@@ -74,6 +83,16 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_08_131207) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "watchlist_tags", force: :cascade do |t|
+    t.bigint "watchlist_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["tag_id"], name: "index_watchlist_tags_on_tag_id"
+    t.index ["watchlist_id", "tag_id"], name: "index_watchlist_tags_on_watchlist_id_and_tag_id", unique: true
+    t.index ["watchlist_id"], name: "index_watchlist_tags_on_watchlist_id"
   end
 
   create_table "watchlists", force: :cascade do |t|
@@ -97,5 +116,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_08_131207) do
   add_foreign_key "notifications", "users"
   add_foreign_key "notifications", "watchlists"
   add_foreign_key "social_accounts", "users"
+  add_foreign_key "tags", "users"
+  add_foreign_key "watchlist_tags", "tags"
+  add_foreign_key "watchlist_tags", "watchlists"
   add_foreign_key "watchlists", "users"
 end

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  name: MyString
+
+two:
+  user: two
+  name: MyString

--- a/test/fixtures/watchlist_tags.yml
+++ b/test/fixtures/watchlist_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  watchlist: one
+  tag: one
+
+two:
+  watchlist: two
+  tag: two

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/watchlist_tag_test.rb
+++ b/test/models/watchlist_tag_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class WatchlistTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

予定にタグを付けて管理できるタグ機能と、タグによる予定の絞り込み検索を実装しました。
複数タグの登録・編集・表示に対応し、一覧画面からタグを検索できるようにしました。

## 背景

予定が増えた際に、アーティスト名やイベント種別などのタグを使って目的の予定を探しやすくするため。
（closes: #90）

## 変更内容

- `Tag` モデルを追加
- `WatchlistTag` 中間モデルを追加
- `Watchlist` と `Tag` を多対多で関連付け
- 予定の新規作成・編集フォームにタグ入力欄を追加
- 複数タグの登録に対応
  - 半角カンマ `,`
  - 全角カンマ `，`
  - 読点 `、`
  を区切り文字として利用可能
- 既存タグは再利用し、存在しないタグは新規作成する処理を追加
- 予定編集時のタグ追加・変更・解除に対応
- 一覧画面・詳細画面にタグを表示
- タグ名の部分一致検索を実装
- 検索対象をログインユーザーの予定に限定
- 検索結果を「これからの予定」「これまでの足跡」に分けて表示
- 検索結果が0件の場合のメッセージを追加
- 絞り込み中のキーワード表示と「絞り込みを解除」ボタンを追加
- タグ検索時の重複表示を防ぐため、`WatchlistTag` を利用したサブクエリ方式で検索
- `Watchlist` の通知用scopeを `WatchlistNotifiable` Concernへ切り出し
- `watchlist_params` を整理し、可読性を改善

## 確認方法

- 予定の新規作成時にタグを登録できること
- 複数のタグを登録できること
- `,` `，` `、` のいずれでもタグを区切れること
- 既存タグがある場合に重複して作成されず再利用されること
- 予定編集時にタグを追加・変更・解除できること
- 一覧画面・詳細画面に登録したタグが表示されること
- 一覧画面でタグ名を入力して検索できること
- タグ名の一部でも検索できること
- 複数のタグが検索条件に一致しても同じ予定が重複表示されないこと
- 検索結果が「これからの予定」のみにある場合、正しく表示されること
- 検索結果が「これまでの足跡」のみにある場合、正しく表示されること
- 両方に検索結果がある場合、両方表示されること
- 検索結果が0件の場合、「一致する予定はありません」と表示されること
- 「絞り込みを解除」から通常の一覧表示に戻れること
- RuboCopがエラーなく通ること

## 影響範囲

- 予定の新規作成・編集
- 予定一覧画面
- 予定詳細画面
- `Watchlist` モデル
- タグ関連モデル・DBテーブル
- 通知対象取得用scopeの配置

通知用scopeはConcernへ移動していますが、既存の通知条件自体は変更していません。

## スクリーンショット

- タグが表示された予定一覧画面
<img width="1919" height="837" alt="image" src="https://github.com/user-attachments/assets/880da20d-9919-453e-b342-396ce1016b26" />

- タグが表示された予定詳細画面
<img width="1919" height="990" alt="image" src="https://github.com/user-attachments/assets/21e4f343-c78b-4c15-a36b-27f33d711c46" />

- タグ検索・絞り込み中の一覧画面
<img width="1915" height="990" alt="image" src="https://github.com/user-attachments/assets/fae9846c-4235-40f3-8e9a-4e2d66e0c81b" />

- 検索結果0件時の画面
<img width="1919" height="992" alt="image" src="https://github.com/user-attachments/assets/cdae406e-c8f7-4397-94a8-38f5a4c438cb" />


## 補足

タグ検索では、複数のタグが部分一致した場合でも同じ予定が重複表示されないよう、`WatchlistTag` のサブクエリから対象の `watchlist_id` を取得する形にしています。

当初は `distinct` を使用しましたが、`upcoming` scopeの `ORDER BY CASE` と組み合わせた際にPostgreSQLの `SELECT DISTINCT` と `ORDER BY` の制約によるエラーが発生したため、サブクエリ方式へ変更しました。

また、タグ機能追加により `Watchlist` モデルが長くなったため、通知対象取得用のscopeを `WatchlistNotifiable` Concernへ切り出して責務を整理しました。