### PR TITLE
スケジュール状態に応じた色分け表示を実装

### DIFF
--- a/app/helpers/watchlists_helper.rb
+++ b/app/helpers/watchlists_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module WatchlistsHelper
+  BORDER_CLASSES = {
+    starting_soon: 'border-[#C0F3B4]',
+    deadline_soon: 'border-[#FCF98B]',
+    deadline_very_soon: 'border-[#FCC2EC]',
+    finished: 'border-gray-300',
+    normal: 'border-[#B6E0F3]'
+  }.freeze
+
+  BADGE_CLASSES = {
+    starting_soon: 'bg-[#C0F3B4]/50',
+    deadline_soon: 'bg-[#FCF98B]/50',
+    deadline_very_soon: 'bg-[#FCC2EC]/50',
+    normal: 'bg-[#B6E0F3]/50'
+  }.freeze
+
+  PIN_CLASSES = {
+    starting_soon: 'text-[#C0F3B4]',
+    deadline_soon: 'text-[#FCF98B]',
+    deadline_very_soon: 'text-[#FCC2EC]',
+    finished: 'text-gray-300',
+    normal: 'text-[#B6E0F3]'
+  }.freeze
+
+  def watchlist_border_class(watchlist)
+    BORDER_CLASSES.fetch(watchlist.schedule_status)
+  end
+
+  def watchlist_badge_class(watchlist)
+    BADGE_CLASSES.fetch(watchlist.schedule_status)
+  end
+
+  def watchlist_pin_class(watchlist)
+    PIN_CLASSES.fetch(watchlist.schedule_status)
+  end
+end

--- a/app/models/concerns/watchlist_schedulable.rb
+++ b/app/models/concerns/watchlist_schedulable.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module WatchlistSchedulable
+  extend ActiveSupport::Concern
+
+  def schedule_status
+    return :finished if finished?
+    return :starting_soon if starting_soon?
+    return :deadline_very_soon if deadline_very_soon?
+    return :deadline_soon if deadline_soon?
+
+    :normal
+  end
+
+  private
+
+  def finished?
+    is_done? || (end_at.present? && end_at < Time.current)
+  end
+
+  def starting_soon?
+    start_at.present? &&
+      start_at > Time.current &&
+      days_until_start&.between?(0, 3)
+  end
+
+  def deadline_very_soon?
+    days_until_end&.between?(0, 1)
+  end
+
+  def deadline_soon?
+    days_until_end&.between?(2, 3)
+  end
+
+  def days_until_end
+    return if end_at.blank?
+
+    (end_at.to_date - Date.current).to_i
+  end
+
+  def days_until_start
+    return if start_at.blank?
+
+    (start_at.to_date - Date.current).to_i
+  end
+end

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -2,6 +2,7 @@
 
 class Watchlist < ApplicationRecord
   include WatchlistNotifiable
+  include WatchlistSchedulable
   attr_accessor :tag_names
 
   belongs_to :user

--- a/app/views/watchlists/_watchlist_card.html.erb
+++ b/app/views/watchlists/_watchlist_card.html.erb
@@ -12,7 +12,7 @@
                   px-4 py-4 sm:p-5
                   sticky-note-shadow
                   border-l-6 sm:border-l-8
-                  <%= is_past ? 'border-gray-300' : 'border-[#B6E0F3]' %>">
+                  <%= watchlist_border_class(watchlist) %>">
 
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <%# 左側：日時・種別・タイトル %>
@@ -71,9 +71,10 @@
       </div>
 
       <%# 右側：ステータス %>
-      <div class="flex items-center justify-between gap-3
-                  sm:flex-col sm:items-end sm:justify-center
+      <div class="flex justify-end gap-3
+                  sm:flex-col sm:items-end sm:justify-start
                   sm:min-h-12
+                  sm:pt-7
                   <%= 'opacity-60' if is_past || watchlist.is_done? %>">
 
         <div>
@@ -90,7 +91,7 @@
               <% days_to_start = (watchlist.start_at.to_date - Date.current).to_i %>
 
               <span class="inline-flex items-center min-h-7
-                           bg-[#B6E0F3]/50 text-[#2d6489]
+                           <%= watchlist_badge_class(watchlist) %> text-[#2d6489]
                            text-[10px] font-bold
                            px-3 py-1
                            rounded-full
@@ -103,7 +104,7 @@
               <% days_left = (watchlist.end_at.to_date - Date.current).to_i %>
 
               <span class="inline-flex items-center min-h-7
-                           bg-[#B6E0F3]/50 text-[#2d6489]
+                           <%= watchlist_badge_class(watchlist) %> text-[#2d6489]
                            text-[10px] font-bold
                            px-3 py-1
                            rounded-full
@@ -138,7 +139,7 @@
             inventory_2
           </span>
         <% else %>
-          <span class="material-symbols-outlined absolute top-4 right-4 text-lg text-[#B6E0F3]"
+          <span class="material-symbols-outlined absolute top-4 right-4 text-lg <%= watchlist_pin_class(watchlist) %>"
                         aria-hidden="true">
             push_pin
           </span>

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -20,7 +20,7 @@
   </div>
 
   <!-- Title Section -->
-  <section class="bg-white p-8 rounded-3xl puffy-shadow relative overflow-hidden border-l-[12px] <%= ( @watchlist.end_at && @watchlist.end_at < Time.current ) ? 'border-gray-300' : 'border-[#B6E0F3]' %>">
+  <section class="bg-white p-8 rounded-3xl puffy-shadow relative overflow-hidden border-l-[12px] <%= watchlist_border_class(@watchlist) %>">
     <p class="font-label text-xs text-on-surface-variant/70 mb-3 flex flex-wrap gap-2">
       <% if @watchlist.reception_detail.present? %>
         <span class="bg-[#B6E0F3]/50 text-[#2d6489] text-sm font-bold px-3 py-1 rounded-full tracking-wider">


### PR DESCRIPTION
## 概要
スケジュールの状態に応じて、一覧画面のカードを色分け表示する機能を実装しました。
詳細画面にも同じステータス色を反映し、予定の状態を視覚的に判別しやすくしました。

## 背景
開始前・締切間近・終了済みなどの予定が同じ色で表示されており、重要な予定を直感的に判別しにくかったため。

closes #77

## 変更内容
- スケジュール状態を判定する `schedule_status` を実装
  - 通常：水色
  - 開始間近（0〜3日前）：黄緑
  - 締切間近（2〜3日前）：黄色
  - 締切直前（当日〜1日前）：ピンク
  - 終了済み・対応済み：グレー
- 開始前は「開始間近」の判定を優先し、開始後は締切までの日数に応じて状態を判定
- 一覧画面の以下の要素にステータス色を反映
  - カード左側のボーダー
  - 開始・締切までの日数バッジ
  - ピンアイコン
- ステータスバッジを右寄せに調整
- 詳細画面のタイトルカード左側のボーダーにもステータス色を反映
- スケジュール状態判定を `WatchlistSchedulable` Concernへ切り出し
- ステータスに応じたCSSクラスの管理を `WatchlistsHelper` へ切り出し

## 確認方法
- 通常の予定が水色で表示されること
- 開始0〜3日前の予定が黄緑で表示されること
- 開始前かつ締切も間近の場合、開始状態が優先されること
- 開始後、締切2〜3日前の予定が黄色で表示されること
- 開始後、締切当日〜1日前の予定がピンクで表示されること
- 締切終了済みの予定がグレーで表示されること
- 対応済みの予定がグレーで表示されること
- 一覧画面と詳細画面で同じステータス色が反映されること
- PC・モバイル表示でレイアウトに問題がないこと
- `bundle exec rubocop` が通ること

## 影響範囲
- スケジュール一覧画面
- スケジュール詳細画面
- スケジュール状態の判定処理
- 予定の登録・編集や通知処理には影響なし

## スクリーンショット

一覧画面
<img width="1387" height="990" alt="image" src="https://github.com/user-attachments/assets/f87061bf-3d57-44ef-9d2a-0945dc13b2e1" />

詳細画面
<img width="1917" height="993" alt="image" src="https://github.com/user-attachments/assets/6a307969-9a7c-4933-a16e-a24e8a033829" />

## 補足
開始と締切の両方が近い場合、数量限定販売や先着受付などでは開始日時の重要度が高いケースもあるため、「開始前は開始を優先し、開始後は締切を優先する」判定としました。

また、ステータス判定と表示用CSSクラスの管理をそれぞれConcern・Helperへ切り出し、ModelやViewに処理が集中しないよう整理しています。