### PR TITLE
使い方ガイドページを追加

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[terms privacy]
+  skip_before_action :authenticate_user!, only: %i[terms privacy guide]
 
   def terms; end
 
   def privacy; end
+
+  def guide; end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -117,13 +117,24 @@
     <!-- Footer Actions -->
     <footer class="flex flex-col items-center space-y-4 pt-4 pb-8">
       <div class="flex flex-col sm:flex-row items-center sm:space-x-2 space-y-1 sm:space-y-0 text-center">
-        <span class="text-gray-500 text-sm">アカウントをお持ちでないですか？</span>
-        <%= link_to "新規登録はこちら", new_registration_path(resource_name), class: "text-primary text-sm font-semibold hover:opacity-70 transition-opacity" %>
+      <span class="text-gray-500 text-sm">アカウントをお持ちでないですか？</span>
+        <%= link_to "新規登録はこちら",
+          new_registration_path(resource_name),
+          class: "text-primary text-sm font-semibold hover:opacity-70 transition-opacity" %>
       </div>
-      <%# classを1つに統合し、横並びや間隔を調整しやすいように調整 %>
-      <div class="flex gap-4">
-        <%= link_to '利用規約', terms_path, class: "text-primary text-sm font-semibold hover:opacity-70 transition-opacity" %>
-        <%= link_to 'プライバシーポリシー', privacy_path, class: "text-primary text-sm font-semibold hover:opacity-70 transition-opacity" %>
+
+      <div class="flex flex-wrap justify-center gap-x-4 gap-y-2">
+        <%= link_to "使い方ガイド",
+          guide_path,
+          class: "text-primary text-sm font-semibold hover:opacity-70 transition-opacity" %>
+
+        <%= link_to "利用規約",
+          terms_path,
+          class: "text-primary text-sm font-semibold hover:opacity-70 transition-opacity" %>
+
+        <%= link_to "プライバシーポリシー",
+          privacy_path,
+          class: "text-primary text-sm font-semibold hover:opacity-70 transition-opacity" %>
       </div>
     </footer>
   </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -148,13 +148,13 @@
       <div class="bg-white rounded-xl p-1 shadow-sm overflow-hidden border border-base-200">
         <%# 1. 使いかたガイド %>
         <div class="border-b border-gray-100 mx-4">
-          <button class="w-full min-h-11 flex items-center justify-between py-4 hover:bg-gray-50 active:bg-gray-50 transition-colors text-left" disabled>
+          <%= link_to guide_path, class: "block w-full min-h-11 flex items-center justify-between py-4 hover:bg-gray-50 active:bg-gray-50 transition-colors text-left" do %>
             <div class="flex items-center gap-2">
               <span class="material-symbols-outlined text-primary/50 text-xl">menu_book</span>
               <span class="text-primary font-medium">使いかたガイド</span>
             </div>
-            <span class="material-symbols-outlined text-on-surface-variant text-lg">open_in_new</span>
-          </button>
+            <span class="material-symbols-outlined text-on-surface-variant text-lg">chevron_right</span>
+          <% end %>
         </div>
 
         <%# 2. 利用規約（blockを追加し、外側をborderを持つdivで包む） %>

--- a/app/views/static_pages/guide.html.erb
+++ b/app/views/static_pages/guide.html.erb
@@ -67,16 +67,22 @@
                     これからの予定
                   </span>
 
-                  <div class="flex items-center justify-center w-11 h-11 rounded-2xl bg-[#B6E0F3] shadow-sm">
-                    <span class="material-symbols-outlined text-primary">
-                      add
+                  <div class="flex flex-col items-center">
+                    <div class="flex items-center justify-center w-11 h-11 rounded-2xl bg-[#B6E0F3] shadow-sm">
+                      <span class="material-symbols-outlined text-primary">
+                        add
+                      </span>
+                    </div>
+
+                    <span class="mt-2 text-primary/70 text-sm leading-none">
+                      ↑
                     </span>
+
+                    <p class="mt-1 text-xs text-primary/70 font-medium whitespace-nowrap">
+                      ここから追加
+                    </p>
                   </div>
                 </div>
-
-                <p class="mt-3 text-xs text-right text-primary/70 font-medium">
-                  ↑ ここから追加
-                </p>
               </div>
             </div>
           </div>

--- a/app/views/static_pages/guide.html.erb
+++ b/app/views/static_pages/guide.html.erb
@@ -1,0 +1,570 @@
+<main class="min-h-screen bg-gradient-to-b from-[#f7fbfe] to-white px-4 py-10">
+  <div class="max-w-3xl mx-auto">
+
+    <!-- ヘッダー -->
+    <section class="text-center mb-12">
+      <div class="inline-flex items-center justify-center w-14 h-14 rounded-full bg-[#B6E0F3]/50 mb-4">
+        <span class="material-symbols-outlined text-primary text-3xl">
+          stars
+        </span>
+      </div>
+
+      <h1 class="font-headline font-extrabold text-3xl md:text-4xl text-primary">
+        使い方ガイド
+      </h1>
+
+      <p class="mt-4 text-gray-600 leading-relaxed">
+        推しの大切な予定を、忘れないために。<br>
+        FanPocketなら、予定の登録から通知までまとめて管理できます。
+      </p>
+    </section>
+
+    <!-- 基本の使い方 -->
+    <section>
+      <div class="text-center mb-8">
+        <p class="font-headline font-bold text-xs uppercase tracking-widest text-primary/60">
+          BASIC GUIDE
+        </p>
+
+        <h2 class="mt-2 font-headline font-extrabold text-2xl text-primary">
+          基本の使い方
+        </h2>
+      </div>
+
+      <!-- STEP一覧 -->
+      <div class="space-y-8">
+
+        <!-- STEP 01 -->
+        <div class="bg-white rounded-3xl shadow-sm border border-gray-100 p-6 md:p-8">
+          <div class="flex items-start gap-4">
+
+            <!-- アイコン -->
+            <div class="shrink-0 flex items-center justify-center w-12 h-12 rounded-2xl bg-[#B6E0F3]/40">
+              <span class="material-symbols-outlined text-primary">
+                add
+              </span>
+            </div>
+
+            <!-- 内容 -->
+            <div class="flex-1">
+              <p class="font-headline font-bold text-xs uppercase tracking-widest text-primary/50">
+                STEP 01
+              </p>
+
+              <h3 class="mt-1 font-headline font-bold text-lg text-gray-800">
+                ＋から予定を追加する
+              </h3>
+
+              <p class="mt-3 text-sm md:text-base text-gray-600 leading-relaxed">
+                一覧画面右下の「＋」を押すと、新しい予定を追加できます。
+                Xや公式サイトなどで見つけた告知URLを貼り付けて、登録を始めましょう。
+              </p>
+
+              <!-- ミニUI -->
+              <div class="mt-6 rounded-2xl bg-[#f7fafc] p-5">
+                <div class="flex items-center justify-between">
+                  <span class="text-sm font-medium text-gray-500">
+                    これからの予定
+                  </span>
+
+                  <div class="flex items-center justify-center w-11 h-11 rounded-2xl bg-[#B6E0F3] shadow-sm">
+                    <span class="material-symbols-outlined text-primary">
+                      add
+                    </span>
+                  </div>
+                </div>
+
+                <p class="mt-3 text-xs text-right text-primary/70 font-medium">
+                  ↑ ここから追加
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- STEP 02 -->
+        <div class="bg-white rounded-3xl shadow-sm border border-gray-100 p-6 md:p-8">
+          <div class="flex items-start gap-4">
+
+            <!-- アイコン -->
+            <div class="shrink-0 flex items-center justify-center w-12 h-12 rounded-2xl bg-[#C0F3B4]/40">
+              <span class="material-symbols-outlined text-primary">
+                edit_calendar
+              </span>
+            </div>
+
+            <!-- 内容 -->
+            <div class="flex-1">
+              <p class="font-headline font-bold text-xs uppercase tracking-widest text-primary/50">
+                STEP 02
+              </p>
+
+              <h3 class="mt-1 font-headline font-bold text-lg text-gray-800">
+                内容を確認して登録する
+              </h3>
+
+              <p class="mt-3 text-sm md:text-base text-gray-600 leading-relaxed">
+                URLを貼り付けると、ページからタイトルや日時候補を取得して入力をサポートします。
+                内容を確認し、必要に応じて修正して登録します。
+              </p>
+
+              <!-- 必須項目 -->
+              <div class="mt-5 grid gap-3 sm:grid-cols-2">
+                <div class="rounded-2xl bg-[#f7fafc] p-4">
+                  <p class="text-xs font-bold text-primary/60">
+                    必須
+                  </p>
+
+                  <p class="mt-1 text-sm font-bold text-gray-700">
+                    タイトル
+                  </p>
+                </div>
+
+                <div class="rounded-2xl bg-[#f7fafc] p-4">
+                  <p class="text-xs font-bold text-primary/60">
+                    どちらか必須
+                  </p>
+
+                  <p class="mt-1 text-sm font-bold text-gray-700">
+                    開始日時 / 締切日時
+                  </p>
+                </div>
+              </div>
+
+              <!-- 自動取得について -->
+              <div class="mt-5 flex gap-3 rounded-2xl bg-[#FCF98B]/30 p-4">
+                <span class="material-symbols-outlined text-yellow-600 text-xl">
+                  lightbulb
+                </span>
+
+                <p class="text-sm text-gray-600 leading-relaxed">
+                  ページによっては、タイトルや日時を取得できない場合があります。
+                  タイトルは取得できても日時を取得できないなど、一部の項目だけ取得されることもあります。
+                  取得できなかった項目は手動で入力できます。
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- STEP 03 -->
+        <div class="bg-white rounded-3xl shadow-sm border border-gray-100 p-6 md:p-8">
+          <div class="flex items-start gap-4">
+
+            <!-- アイコン -->
+            <div class="shrink-0 flex items-center justify-center w-12 h-12 rounded-2xl bg-[#FCC2EC]/40">
+              <span class="material-symbols-outlined text-primary">
+                view_list
+              </span>
+            </div>
+
+            <!-- 内容 -->
+            <div class="flex-1">
+              <p class="font-headline font-bold text-xs uppercase tracking-widest text-primary/50">
+                STEP 03
+              </p>
+
+              <h3 class="mt-1 font-headline font-bold text-lg text-gray-800">
+                一覧で予定を管理する
+              </h3>
+
+              <p class="mt-3 text-sm md:text-base text-gray-600 leading-relaxed">
+                登録した予定は「これからの予定」にまとまります。
+                開始や締切が近づくとカードの色が変わるので、確認したい予定をひと目で見つけられます。
+              </p>
+
+              <!-- 状態色 -->
+              <div class="mt-5 grid gap-3 sm:grid-cols-2">
+
+              <!-- 通常 -->
+                <div class="flex items-center gap-3 rounded-2xl bg-[#f7fafc] p-4">
+                  <span class="w-3 h-3 shrink-0 rounded-full bg-[#B6E0F3]"></span>
+
+                  <div>
+                    <p class="text-sm font-bold text-gray-700">
+                      通常の予定
+                    </p>
+
+                  <p class="text-xs text-gray-500">
+                    開始・締切が近づく前の予定
+                  </p>
+                </div>
+              </div>
+
+              <!-- 開始が近い -->
+              <div class="flex items-center gap-3 rounded-2xl bg-[#f7fafc] p-4">
+                <span class="w-3 h-3 shrink-0 rounded-full bg-[#C0F3B4]"></span>
+
+                <div>
+                  <p class="text-sm font-bold text-gray-700">
+                    開始が近い
+                  </p>
+
+                  <p class="text-xs text-gray-500">
+                    開始3日前〜当日の予定
+                  </p>
+                </div>
+              </div>
+
+              <!-- 締切が近い -->
+              <div class="flex items-center gap-3 rounded-2xl bg-[#f7fafc] p-4">
+                <span class="w-3 h-3 shrink-0 rounded-full bg-[#FCF98B]"></span>
+
+                <div>
+                  <p class="text-sm font-bold text-gray-700">
+                    締切が近い
+                  </p>
+
+                  <p class="text-xs text-gray-500">
+                    締切3日前〜2日前の予定
+                  </p>
+                </div>
+              </div>
+
+              <!-- 締切間近 -->
+              <div class="flex items-center gap-3 rounded-2xl bg-[#f7fafc] p-4">
+                <span class="w-3 h-3 shrink-0 rounded-full bg-[#FCC2EC]"></span>
+
+                <div>
+                  <p class="text-sm font-bold text-gray-700">
+                    締切間近
+                  </p>
+
+                  <p class="text-xs text-gray-500">
+                    締切前日〜当日の予定
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <!-- 完了について -->
+            <div class="mt-5 rounded-2xl bg-[#f7fafc] p-5">
+              <div class="flex items-start gap-3">
+                <span class="material-symbols-outlined text-primary">
+                  check_circle
+                </span>
+
+                <div>
+                  <p class="text-sm font-bold text-gray-700">
+                    対応が終わったら「完了」に
+                  </p>
+
+                  <p class="mt-2 text-sm text-gray-600 leading-relaxed">
+                    申し込みや購入などが終わった予定は、編集画面から「完了」にできます。
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <!-- 完了後の通知 -->
+              <div class="mt-3 flex gap-3 rounded-2xl bg-[#FCC2EC]/25 p-4">
+                <span class="material-symbols-outlined text-pink-500 text-xl">
+                  notifications_off
+                </span>
+
+                <p class="text-sm text-gray-600 leading-relaxed">
+                  「完了」にした予定は通知の対象外になります。
+                  メールやLINEなどのお知らせは届きません。
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        <!-- STEP 04 -->
+        <div class="bg-white rounded-3xl shadow-sm border border-gray-100 p-6 md:p-8">
+          <div class="flex items-start gap-4">
+
+            <!-- アイコン -->
+            <div class="shrink-0 flex items-center justify-center w-12 h-12 rounded-2xl bg-[#FCF98B]/50">
+              <span class="material-symbols-outlined text-primary">
+                notifications
+              </span>
+            </div>
+
+            <!-- 内容 -->
+            <div class="flex-1">
+              <p class="font-headline font-bold text-xs uppercase tracking-widest text-primary/50">
+                STEP 04
+              </p>
+
+              <h3 class="mt-1 font-headline font-bold text-lg text-gray-800">
+                通知でうっかりを防ぐ
+              </h3>
+
+              <p class="mt-3 text-sm md:text-base text-gray-600 leading-relaxed">
+                未対応の予定を、設定した通知方法やタイミングに合わせてお知らせします。
+                メールで事前に確認したり、LINEで直前のお知らせを受け取ったりできます。
+              </p>
+
+              <!-- 通知方法 -->
+              <div class="mt-5 grid gap-3 sm:grid-cols-2">
+
+                <!-- メール -->
+                <div class="rounded-2xl bg-[#f7fafc] p-5">
+                  <div class="flex items-center gap-3">
+                    <span class="material-symbols-outlined text-primary">
+                      mail
+                    </span>
+
+                    <div>
+                      <p class="text-sm font-bold text-gray-700">
+                        メール
+                      </p>
+
+                      <p class="text-xs text-gray-500">
+                        事前に予定をチェック
+                      </p>
+                    </div>
+                  </div>
+
+                  <ul class="mt-4 space-y-2 text-sm text-gray-600">
+                    <li class="flex items-center gap-2">
+                      <span class="w-2 h-2 rounded-full bg-[#B6E0F3]"></span>
+                      締切3日前
+                    </li>
+
+                    <li class="flex items-center gap-2">
+                      <span class="w-2 h-2 rounded-full bg-[#B6E0F3]"></span>
+                      締切前日
+                    </li>
+
+                    <li class="flex items-center gap-2">
+                      <span class="w-2 h-2 rounded-full bg-[#B6E0F3]"></span>
+                      締切当日
+                    </li>
+
+                    <li class="flex items-center gap-2">
+                      <span class="w-2 h-2 rounded-full bg-[#B6E0F3]"></span>
+                      開始当日
+                    </li>
+                  </ul>
+                </div>
+
+                <!-- LINE -->
+                <div class="rounded-2xl bg-[#f7fafc] p-5">
+                  <div class="flex items-center gap-3">
+                    <span class="material-symbols-outlined text-primary">
+                      chat
+                    </span>
+
+                    <div>
+                      <p class="text-sm font-bold text-gray-700">
+                        LINE
+                      </p>
+
+                      <p class="text-xs text-gray-500">
+                        直前の行動をサポート
+                      </p>
+                    </div>
+                  </div>
+
+                  <ul class="mt-4 space-y-2 text-sm text-gray-600">
+                    <li class="flex items-center gap-2">
+                      <span class="w-2 h-2 rounded-full bg-[#C0F3B4]"></span>
+                      開始10分前
+                    </li>
+
+                    <li class="flex items-center gap-2">
+                      <span class="w-2 h-2 rounded-full bg-[#C0F3B4]"></span>
+                      締切3時間前
+                    </li>
+                  </ul>
+                </div>
+              </div>
+
+              <!-- 通知設定 -->
+              <div class="mt-5 flex gap-3 rounded-2xl bg-[#B6E0F3]/25 p-4">
+                <span class="material-symbols-outlined text-primary text-xl">
+                  tune
+                </span>
+
+                <p class="text-sm text-gray-600 leading-relaxed">
+                  通知の種類は設定画面から変更できます。
+                  必要な通知だけを選んで利用できます。
+                </p>
+              </div>
+
+              <!-- LINE連携 -->
+              <div class="mt-3 flex gap-3 rounded-2xl bg-[#C0F3B4]/25 p-4">
+                <span class="material-symbols-outlined text-primary text-xl">
+                   person_add
+                </span>
+
+                <p class="text-sm text-gray-600 leading-relaxed">
+                  LINE通知を利用するには、設定画面からLINEアカウントを連携してください。
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+      <!-- /STEP一覧 -->
+    </section>
+
+        </section>
+
+    <!-- もっと便利に使う -->
+    <section class="mt-16">
+      <div class="text-center mb-8">
+        <p class="font-headline font-bold text-xs uppercase tracking-widest text-primary/60">
+          MORE FEATURES
+        </p>
+
+        <h2 class="mt-2 font-headline font-extrabold text-2xl text-primary">
+          もっと便利に使う
+        </h2>
+
+        <p class="mt-3 text-sm md:text-base text-gray-600 leading-relaxed">
+          必須ではありませんが、予定に情報を追加すると
+          もっと分かりやすく整理できます。
+        </p>
+      </div>
+
+      <div class="grid gap-4 md:grid-cols-3">
+
+        <!-- 種別 -->
+        <div class="bg-white rounded-3xl shadow-sm border border-gray-100 p-6">
+          <div class="flex items-center justify-center w-11 h-11 rounded-2xl bg-[#B6E0F3]/40">
+            <span class="material-symbols-outlined text-primary">
+              category
+            </span>
+          </div>
+
+          <h3 class="mt-4 font-headline font-bold text-base text-gray-800">
+            種別
+          </h3>
+
+          <p class="mt-2 text-sm text-gray-600 leading-relaxed">
+            「抽選」「先着」「受注販売」など、予定の種類を設定できます。
+          </p>
+
+          <div class="mt-4 flex flex-wrap gap-2">
+            <span class="rounded-full bg-[#B6E0F3]/50 px-3 py-1 text-xs text-[#2d6489]">
+              抽選
+            </span>
+
+            <span class="rounded-full bg-[#B6E0F3]/50 px-3 py-1 text-xs text-[#2d6489]">
+              先着
+            </span>
+
+            <span class="rounded-full bg-[#B6E0F3]/50 px-3 py-1 text-xs text-[#2d6489]">
+              受注販売
+            </span>
+          </div>
+        </div>
+
+        <!-- 種別詳細 -->
+        <div class="bg-white rounded-3xl shadow-sm border border-gray-100 p-6">
+          <div class="flex items-center justify-center w-11 h-11 rounded-2xl bg-[#FCF98B]/50">
+            <span class="material-symbols-outlined text-primary">
+              label
+            </span>
+          </div>
+
+          <h3 class="mt-4 font-headline font-bold text-base text-gray-800">
+            種別詳細
+          </h3>
+
+          <p class="mt-2 text-sm text-gray-600 leading-relaxed">
+            「FC先行」「一般販売」など、予定についてさらに詳しい情報を残せます。
+          </p>
+
+          <div class="mt-4 rounded-2xl bg-[#f7fafc] px-4 py-3">
+            <p class="text-xs text-gray-400">
+              例
+            </p>
+
+            <p class="mt-1 text-sm font-medium text-gray-700">
+              FC先行
+            </p>
+          </div>
+        </div>
+
+        <!-- タグ -->
+        <div class="bg-white rounded-3xl shadow-sm border border-gray-100 p-6">
+          <div class="flex items-center justify-center w-11 h-11 rounded-2xl bg-[#FCC2EC]/40">
+            <span class="material-symbols-outlined text-primary">
+              tag
+            </span>
+          </div>
+
+          <h3 class="mt-4 font-headline font-bold text-base text-gray-800">
+            タグ
+          </h3>
+
+          <p class="mt-2 text-sm text-gray-600 leading-relaxed">
+            グループ名やメンバー名など、好きなタグを付けて予定を整理できます。
+          </p>
+
+          <div class="mt-4 flex flex-wrap gap-2">
+            <span class="text-sm font-medium text-primary/70">
+              #グループ名
+            </span>
+
+            <span class="text-sm font-medium text-primary/70">
+              #メンバー名
+            </span>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+        <!-- CTA -->
+    <section class="mt-16 mb-8">
+      <div class="rounded-3xl bg-[#B6E0F3]/25 px-6 py-10 md:px-10 md:py-12 text-center">
+        <div class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-white mb-4">
+          <span class="material-symbols-outlined text-primary text-2xl">
+            stars
+          </span>
+        </div>
+
+        <h2 class="font-headline font-extrabold text-2xl text-primary">
+          大切な予定を、もう見逃さない。
+        </h2>
+
+        <p class="mt-3 text-sm md:text-base text-gray-600 leading-relaxed">
+          FanPocketで、推し活の予定をまとめて管理してみましょう。
+        </p>
+
+        <div class="mt-7">
+          <% if user_signed_in? %>
+            <%= link_to new_watchlist_path,
+              class: "inline-flex items-center justify-center gap-2 rounded-full bg-[#B6E0F3] px-8 py-3.5 font-bold text-[#2d6489] shadow-sm transition hover:opacity-80" do %>
+              <span class="material-symbols-outlined text-xl">
+                add
+              </span>
+              予定を追加してみる
+            <% end %>
+          <% else %>
+            <%= link_to new_user_registration_path,
+              class: "inline-flex items-center justify-center gap-2 rounded-full bg-[#B6E0F3] px-8 py-3.5 font-bold text-[#2d6489] shadow-sm transition hover:opacity-80" do %>
+              <span class="material-symbols-outlined text-xl">
+                arrow_forward
+              </span>
+              FanPocketをはじめる
+            <% end %>
+          <% end %>
+        </div>
+
+        <% unless user_signed_in? %>
+          <p class="mt-5 text-sm text-gray-500">
+            すでにアカウントをお持ちの方は
+            <%= link_to "ログイン", new_user_session_path,
+              class: "font-bold text-primary hover:underline" %>
+          </p>
+        <% end %>
+      </div>
+    </section>
+
+    <div class="mt-12 flex justify-center">
+      <button onclick="history.back()" class="text-primary font-bold text-lg gap-2 px-6 hover:opacity-70 transition-opacity">
+        もどる
+      </button>
+    </div>
+
+  </div>
+  <!-- /max-w-3xl -->
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   
   get 'terms', to: 'static_pages#terms'
   get 'privacy', to: 'static_pages#privacy'
+  get 'guide', to: 'static_pages#guide', as: :guide
   # Defines the root path route ("/")
   # root "posts#index"
 


### PR DESCRIPTION
## 概要

未ログインユーザーでも閲覧できる「使い方ガイド」ページを追加しました。
予定の登録から管理・通知まで、FanPocketの基本的な使い方を確認できるようにしました。

## 背景

初めてアプリを訪れたユーザーが、FanPocketでできることや基本的な使い方を理解し、スムーズに利用を開始できるようにするため。

closes #72

## 変更内容

- `/guide` で閲覧できる使い方ガイドページを追加
- `StaticPagesController` に `guide` アクションを追加
- 未ログイン状態でも使い方ガイドを閲覧できるように認証対象外へ追加
- 基本的な使い方を4STEPで掲載
  - 「＋」から予定を追加
  - URLから取得したタイトル・日時候補を確認して登録
  - 一覧画面で予定の状態を確認・管理
  - メール・LINE通知で未対応の予定を確認
- URLによってタイトルや日時を取得できない場合や、一部のみ取得される場合があることを案内
- 一覧カードの状態色について、実際の判定条件に合わせて説明を追加
- 「完了」にした予定はメール・LINEなどの通知対象外になることを案内
- メールとLINEそれぞれの通知タイミングを掲載
- LINE通知にはLINEアカウント連携が必要であることを案内
- 種別・種別詳細・タグを「もっと便利に使う」機能として紹介
- ログイン状態に応じてガイド下部のCTAを切り替え
  - 未ログイン：新規登録への導線
  - ログイン済み：予定追加への導線
- ログイン画面のフッターに「使い方ガイド」へのリンクを追加
- 設定画面の「使い方ガイド」からガイドページへ遷移できるように変更
- ガイド下部に「もどる」ボタンを追加
- PC・スマートフォンに対応したレスポンシブUIを実装

## 確認方法

- 未ログイン状態で `/guide` にアクセスできることを確認
- ログイン画面の「使い方ガイド」からガイドページへ遷移できることを確認
- ログイン済み状態で設定画面の「使い方ガイド」から遷移できることを確認
- 未ログイン時に「FanPocketをはじめる」から新規登録画面へ遷移できることを確認
- 未ログイン時に「ログイン」からログイン画面へ遷移できることを確認
- ログイン済み時に「予定を追加してみる」から予定追加画面へ遷移できることを確認
- 「もどる」ボタンで遷移元の画面へ戻れることを確認
- PC・スマートフォンでレイアウトが崩れないことを確認
- RuboCopが正常に通ることを確認

## 影響範囲

- 使い方ガイドページ
- ログイン画面のフッター
- 設定画面の使い方ガイド導線
- 既存の予定登録・編集・通知処理などのロジックには影響なし

## スクリーンショット

- 使い方ガイド全体
<img width="692" height="989" alt="image" src="https://github.com/user-attachments/assets/effa8536-555a-4ebc-881c-6c2796a4ffa6" />

- スマートフォン表示
<img width="921" height="992" alt="image" src="https://github.com/user-attachments/assets/166171ff-ce09-41a8-98a7-9c681c2c8957" />

- 未ログイン時のCTA
<img width="1187" height="551" alt="image" src="https://github.com/user-attachments/assets/48edf7fb-9fd6-49e4-85b5-6a934688de69" />

-  ログイン時のCTA
<img width="1119" height="517" alt="image" src="https://github.com/user-attachments/assets/ecfe8fc9-6f58-414c-ac26-6680320f9a4b" />

## 補足

使い方ガイドでは、初めて利用するユーザーが情報過多にならないよう、基本操作を中心に掲載しています。
種別・種別詳細・タグなどの任意項目は「もっと便利に使う」として基本操作と分けて紹介しています。

また、一覧画面の状態色については、実際のステータス判定と説明内容が一致するよう調整しています。