### PR TITLE
新規ユーザー向けオンボーディングを実装

### DIFF
--- a/app/controllers/onboardings_controller.rb
+++ b/app/controllers/onboardings_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class OnboardingsController < ApplicationController
+  def update
+    current_user.update!(onboarding_completed_at: Time.current)
+
+    redirect_to watchlists_path
+  end
+end

--- a/app/controllers/watchlists_controller.rb
+++ b/app/controllers/watchlists_controller.rb
@@ -27,6 +27,8 @@ class WatchlistsController < ApplicationController
 
     if @watchlist.save
       @watchlist.save_tags
+      current_user.update!(onboarding_completed_at: Time.current) if current_user.onboarding_completed_at.nil?
+
       redirect_to watchlists_path, notice: '新しい予定を登録しました'
     else
       render :new, status: :unprocessable_entity

--- a/app/helpers/onboardings_helper.rb
+++ b/app/helpers/onboardings_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module OnboardingsHelper
+end

--- a/app/models/watchlist.rb
+++ b/app/models/watchlist.rb
@@ -22,7 +22,7 @@ class Watchlist < ApplicationRecord
 
   validate :end_at_must_be_future, on: :create
   validate :end_at_must_be_after_start_at
-  
+
   validates :reception_detail, length: { maximum: 20 }, allow_blank: true
 
   enum :reception_type, {

--- a/app/views/watchlists/_welcome_onboarding.html.erb
+++ b/app/views/watchlists/_welcome_onboarding.html.erb
@@ -1,0 +1,61 @@
+<div class="mb-6">
+  <div class="flex flex-col items-center justify-center
+              px-6 py-10 md:py-12
+              text-center bg-white/70 rounded-3xl
+              shadow-sm border border-[#B6E0F3]/60">
+
+    <span class="material-symbols-outlined text-5xl text-[#B6E0F3] mb-4">
+      auto_awesome
+    </span>
+
+    <h3 class="font-headline font-extrabold text-xl sm:text-2xl text-primary">
+      FanPocketへようこそ！
+    </h3>
+
+    <p class="mt-3 text-[#4f5052] text-sm sm:text-base leading-relaxed">
+      まずは気になる予定を1件登録してみましょう。<br>
+      告知ページのURLから、予定をかんたんに登録できます。
+    </p>
+
+    <div class="mt-6 flex flex-col sm:flex-row items-center justify-center gap-3 w-full">
+      <%= link_to new_watchlist_path,
+          class: "w-full sm:w-auto
+                  inline-flex items-center justify-center gap-2
+                  px-6 py-3 rounded-full
+                  bg-[#B6E0F3] text-[#2d6489]
+                  font-bold shadow-sm
+                  hover:brightness-105
+                  active:scale-95
+                  transition-all" do %>
+        <span class="material-symbols-outlined text-xl">
+          add
+        </span>
+        最初のスケジュールを登録する
+      <% end %>
+
+      <%= link_to guide_path,
+          class: "w-full sm:w-auto
+                  inline-flex items-center justify-center gap-2
+                  px-6 py-3 rounded-full
+                  bg-white text-primary
+                  font-bold border border-[#B6E0F3]
+                  hover:bg-[#B6E0F3]/20
+                  active:scale-95
+                  transition-all" do %>
+        <span class="material-symbols-outlined text-xl">
+          menu_book
+        </span>
+        使い方ガイドを見る
+      <% end %>
+    </div>
+    <%= button_to onboarding_path,
+        method: :patch,
+        class: "mt-5 text-sm text-[#4f5052]/70
+                hover:text-primary
+                underline underline-offset-4
+                transition-colors" do %>
+      案内を閉じる
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/watchlists/_welcome_onboarding.html.erb
+++ b/app/views/watchlists/_welcome_onboarding.html.erb
@@ -49,12 +49,10 @@
       <% end %>
     </div>
     <%= button_to onboarding_path,
-        method: :patch,
-        class: "mt-5 text-sm text-[#4f5052]/70
-                hover:text-primary
-                underline underline-offset-4
-                transition-colors" do %>
-      案内を閉じる
+      method: :patch,
+      class: "mt-5 text-primary text-sm font-semibold
+              hover:opacity-70 transition-opacity" do %>
+        案内を閉じる
     <% end %>
   </div>
 </div>

--- a/app/views/watchlists/index.html.erb
+++ b/app/views/watchlists/index.html.erb
@@ -96,21 +96,30 @@
 
     <% elsif params[:tag].blank? %>
       <%# 検索していない＆これからの予定がない場合 %>
-      <div class="mb-6">
-        <div class="flex flex-col items-center justify-center
-                    px-5 py-10 md:py-12
-                    text-center bg-white/30 rounded-3xl
-                    border border-dashed border-[#4f5052]">
 
-          <span class="material-symbols-outlined text-4xl text-[#B6E0F3] mb-2">
-            auto_awesome
-          </span>
+      <% if current_user.onboarding_completed_at.nil? &&
+          @future_watchlists.empty? &&
+          @past_watchlists.empty? %>
 
-          <p class="text-[#4f5052] text-sm sm:text-base font-headline font-bold leading-relaxed">
-            お気に入りの予定を、ポケットに入れて持ち歩こう。
-          </p>
+        <%= render "welcome_onboarding" %>
+
+      <% else %>
+        <div class="mb-6">
+          <div class="flex flex-col items-center justify-center
+                      px-5 py-10 md:py-12
+                      text-center bg-white/30 rounded-3xl
+                      border border-dashed border-[#4f5052]">
+
+            <span class="material-symbols-outlined text-4xl text-[#B6E0F3] mb-2">
+              auto_awesome
+            </span>
+
+            <p class="text-[#4f5052] text-sm sm:text-base font-headline font-bold leading-relaxed">
+              お気に入りの予定を、ポケットに入れて持ち歩こう。
+            </p>
+          </div>
         </div>
-      </div>
+      <% end %>
     <% end %>
 
     <%# 終わった予定セクション %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
   resources :watchlists, only: [:index, :show, :new, :create, :edit, :update, :destroy]
   resources :notifications, only: [:index, :show]
   resource :settings, only: [:show, :update]
+  resource :onboarding, only: :update
   
   resources :url_parsers, only: [] do
     collection do

--- a/db/migrate/20260816060143_add_onboarding_completed_at_to_users.rb
+++ b/db/migrate/20260816060143_add_onboarding_completed_at_to_users.rb
@@ -1,0 +1,16 @@
+class AddOnboardingCompletedAtToUsers < ActiveRecord::Migration[7.1]
+  class MigrationUser < ActiveRecord::Base
+    self.table_name = 'users'
+  end
+
+  def up
+    add_column :users, :onboarding_completed_at, :datetime
+
+    MigrationUser.reset_column_information
+    MigrationUser.update_all(onboarding_completed_at: Time.current)
+  end
+
+  def down
+    remove_column :users, :onboarding_completed_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_11_091719) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_16_060143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -80,6 +80,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_11_091719) do
     t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
+    t.datetime "onboarding_completed_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/test/controllers/onboardings_controller_test.rb
+++ b/test/controllers/onboardings_controller_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class OnboardingsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

新規ユーザー向けのオンボーディング機能を実装しました。
新規登録後、予定がまだないユーザーにウェルカムカードを表示し、最初の予定登録へ誘導します。

## 背景

新規登録直後は予定が1件もなく、次に何をすればよいか分かりづらいため、
最初の予定登録までスムーズに進めるための初回案内を追加しました。

closes #73

## 変更内容

- `users`テーブルに`onboarding_completed_at`カラムを追加
- マイグレーション実行時の既存ユーザーをオンボーディング完了済みに設定
- 新規ユーザーかつ予定が0件の場合にウェルカムカードを表示
- ウェルカムカードから以下の操作ができるように変更
  - 最初のスケジュールを登録する
  - 使い方ガイドを見る
  - 案内を閉じる
- オンボーディング完了処理用の`OnboardingsController`を追加
- 「案内を閉じる」操作時に`onboarding_completed_at`を更新
- 最初の予定登録成功時に`onboarding_completed_at`を更新
- オンボーディング完了後は、予定をすべて削除して0件になってもウェルカムカードを再表示しないように対応
- 既存ユーザーにはウェルカムカードを表示せず、従来の空状態表示を維持

## 確認方法

- 新規登録したユーザーの`onboarding_completed_at`が`nil`になることを確認
- 新規ユーザーかつ予定0件の場合にウェルカムカードが表示されることを確認
- 既存ユーザーにはウェルカムカードが表示されないことを確認
- 「最初のスケジュールを登録する」から予定を登録できることを確認
- 最初の予定登録後、`onboarding_completed_at`に日時が保存されることを確認
- 「案内を閉じる」操作後、`onboarding_completed_at`に日時が保存されることを確認
- 案内を閉じたあと、再読み込みしてもウェルカムカードが再表示されないことを確認
- 最初に登録した予定を削除して0件に戻しても、ウェルカムカードが再表示されないことを確認
- 既存ユーザーで予定が0件の場合、従来の空状態が表示されることを確認
- RuboCopがエラーなく通ることを確認

## 影響範囲

- 新規登録後の予定一覧画面
- 予定の新規登録処理
- ユーザーのオンボーディング状態管理
- 既存ユーザーはオンボーディング完了済みとして扱うため、通常利用への影響なし

## スクリーンショット

- 新規登録直後に表示されるウェルカムカードのスクリーンショットを添付
<img width="1329" height="796" alt="image" src="https://github.com/user-attachments/assets/c6dd9731-d0bb-40d3-95ce-f9a2d7266d14" />

## 補足

オンボーディング状態は`onboarding_completed_at`で管理しています。

マイグレーション実行時点ですでに存在するユーザーには完了日時を設定し、それ以降に登録されたユーザーは`nil`から開始することで、既存ユーザーに初回案内が表示されないようにしています。

また、予定の有無だけで表示を判定すると、登録した予定をすべて削除した際にウェルカムカードが再表示されてしまうため、オンボーディング完了状態をDBで保持する設計としています。