### PR TITLE
GitHub ActionsによるCI（自動テスト）環境の構築

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Prepare database
         run: bin/rails db:prepare
 
+      - name: Build Tailwind CSS
+        run: bin/rails tailwindcss:build
+
       - name: Run RuboCop
         run: bundle exec rubocop
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: app_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:password@localhost:5432/app_test
+
+      MAILER_SENDER: test@example.com
+
+      GOOGLE_CLIENT_ID: dummy
+      GOOGLE_CLIENT_SECRET: dummy
+
+      LINE_LOGIN_CHANNEL_ID: dummy
+      LINE_LOGIN_CHANNEL_SECRET: dummy
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2.2"
+          bundler-cache: true
+
+      - name: Prepare database
+        run: bin/rails db:prepare
+
+      - name: Run RuboCop
+        run: bundle exec rubocop
+
+      - name: Run RSpec
+        run: bundle exec rspec


### PR DESCRIPTION
## 概要

GitHub Actionsを利用したCI環境を構築し、Push・Pull Request時にRuboCopとRSpecが自動実行されるようにしました。  
あわせてmainブランチにRulesetを設定し、CI成功とPull Request経由でのマージを必須化しました。

## 背景

ローカル環境での手動確認だけでは、RuboCopやRSpecの実行忘れにより、問題のあるコードをマージしてしまう可能性があるためです。

GitHub Actionsによる自動チェックを導入し、コードの品質を継続的に確認できる開発フローを整備しました。

Closes #88

## 変更内容

- `.github/workflows/ci.yml` を追加
- Push・Pull RequestをトリガーにGitHub Actionsが実行されるよう設定
- CI用のPostgreSQL 16を起動する設定を追加
- Ruby 3.2.2のセットアップを追加
- テスト用データベースの準備処理を追加
- CI環境で必要な環境変数にダミー値を設定
- Tailwind CSSのビルド処理を追加
- RuboCopの自動実行を追加
- RSpecの自動実行を追加
- mainブランチにRulesetを設定
  - Pull Request経由でのマージを必須化
  - GitHub Actionsの `test` 成功を必須チェックに設定
  - mainブランチの削除・force pushを制限

## 確認方法

- featureブランチをGitHubへPushする
- GitHub ActionsのCIが自動実行されることを確認
- PostgreSQLの起動・DB準備・Tailwind CSSビルドが成功することを確認
- RuboCopが成功することを確認
- RSpecが成功することを確認
- GitHub Actionsの `test` が緑のチェックになることを確認
- Pull Requestで必須チェックとして `test` が設定されていることを確認
- CI成功後にmainブランチへマージ可能になることを確認

## 影響範囲

- GitHubへのPush・Pull Request作成時にCIが自動実行されます
- mainブランチへの変更はPull Request経由かつCI成功後のみマージ可能になります
- アプリ本体の機能やUIへの変更はありません

## 補足

初回のCI実行では、RSpec実行時に `tailwind.css` が存在せず、Request Spec 77件中9件が失敗しました。

CI環境ではローカル環境と異なりTailwind CSSが生成されていなかったことが原因だったため、以下のビルド処理を追加しました。

~~~yaml
- name: Build Tailwind CSS
  run: bin/rails tailwindcss:build
~~~

修正後に再度GitHub Actionsを実行し、RuboCop・RSpecを含むすべての処理が成功することを確認しています。