### PR TITLE
UI/UXの修正

### DIFF
--- a/app/javascript/controllers/watchlist_form_controller.js
+++ b/app/javascript/controllers/watchlist_form_controller.js
@@ -41,13 +41,13 @@ export default class extends Controller {
         clearInterval(interval)
         
         if (startConnected) {
-          this.startAtInputTarget._flatpickr.set('onChange', this.checkStartDate)
-          this.startAtInputTarget._flatpickr.set('onClose', this.checkStartDate)
+          this.startAtInputTarget._flatpickr.set('onChange', () => this.checkStartDate())
+          this.startAtInputTarget._flatpickr.set('onClose', () => this.checkStartDate())
         }
         
         if (endConnected) {
-          this.endAtInputTarget._flatpickr.set('onChange', this.checkDate)
-          this.endAtInputTarget._flatpickr.set('onClose', this.checkDate)
+          this.endAtInputTarget._flatpickr.set('onChange', () => this.checkDate())
+          this.endAtInputTarget._flatpickr.set('onClose', () => this.checkDate())
         }
       } else if (attempts > 10) {
         clearInterval(interval)
@@ -183,6 +183,8 @@ export default class extends Controller {
 
         startButton.addEventListener("click", () => {
           this.insertDateTime("開始", suggestion.value)
+          choiceContainer.remove()
+          button.textContent = `${suggestion.label.replace(/^候補: /, "")} ▾`
         })
 
         const endButton = document.createElement("button")
@@ -192,6 +194,8 @@ export default class extends Controller {
 
         endButton.addEventListener("click", () => {
           this.insertDateTime("締切", suggestion.value)
+          choiceContainer.remove()
+          button.textContent = `${suggestion.label.replace(/^候補: /, "")} ▾`
         })
 
         const buttonRow = document.createElement("div")

--- a/app/mailers/email_change_mailer.rb
+++ b/app/mailers/email_change_mailer.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class EmailChangeMailer < ApplicationMailer
-  default from: 'no-reply@fanpocket.fun'
-
   def email_changed(user)
     @user = user
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class NotificationMailer < ApplicationMailer
-  default from: 'noreply@fanpocket.fun'
-
   def send_notice(user_email, title, content)
     @title = title
     @content = content

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -5,34 +5,34 @@ class NotificationMailer < ApplicationMailer
     @title = title
     @content = content
 
-    mail(to: user_email, subject: "【FanPocket】新しいお知らせ: #{@title}")
+    mail(to: user_email, subject: "【FanPocket】🌟新しいお知らせ：#{@title}")
   end
 
   # 3日前通知
   def three_days_ago_notice(user_email, title, content)
     @title = title
     @content = content
-    mail(to: user_email, subject: "【FanPocket】あと3日で締切です：#{@title}")
+    mail(to: user_email, subject: "【FanPocket】📅あと3日で締切です：#{@title}")
   end
 
   # 前日20時通知
   def day_before_notice(user_email, title, content)
     @title = title
     @content = content
-    mail(to: user_email, subject: "【FanPocket】明日締切です：#{@title}")
+    mail(to: user_email, subject: "【FanPocket】🌟明日締切です：#{@title}")
   end
 
   # 当日7時通知
   def today_notice(user_email, title, content)
     @title = title
     @content = content
-    mail(to: user_email, subject: "【FanPocket】本日締切です：#{@title}")
+    mail(to: user_email, subject: "【FanPocket】⏰本日締切です：#{@title}")
   end
 
   def start_notice(user_email, title, content)
     @title = title
     @content = content
 
-    mail(to: user_email, subject: "【FanPocket】本日開始です：#{@title}")
+    mail(to: user_email, subject: "【FanPocket】✨本日開始です：#{@title}")
   end
 end

--- a/app/mailers/welcome_mailer.rb
+++ b/app/mailers/welcome_mailer.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class WelcomeMailer < ApplicationMailer
-  default from: 'no-reply@fanpocket.fun'
-
   def send_welcome_email(user)
     @user = user
     # メールの添付データとしてロゴ画像を登録（インライン配置用）

--- a/app/views/layouts/_app_navigation.html.erb
+++ b/app/views/layouts/_app_navigation.html.erb
@@ -2,5 +2,7 @@
   <%= render "layouts/header",
              back_path: local_assigns[:back_path] %>
 
+  <div class="hidden md:block h-[86px]" aria-hidden="true"></div>
+
   <%= render "layouts/sidebar" %>
 </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="bg-white/80 backdrop-blur-sm sticky top-0 z-40
+<header class="bg-white/80 backdrop-blur-sm sticky top-0 md:fixed md:left-0 md:right-0 z-40
                transition-colors border-b border-white shadow-sm">
   <div class="relative flex items-center justify-center w-full px-4 py-5">
     <div class="absolute left-4 flex items-center">

--- a/app/views/watchlists/_form.html.erb
+++ b/app/views/watchlists/_form.html.erb
@@ -17,7 +17,7 @@
     
     <%= f.url_field :url, 
         data: { watchlist_form_target: "urlInput" },
-        class: "w-full h-14 pl-14 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:url].any?}", placeholder: "https://example.com/event-page" %>
+        class: "w-full h-14 px-6 pr-8 bg-[#f0f4f8] border-none rounded-full shadow-inner focus:outline-none focus:ring-2 focus:ring-primary focus:bg-white transition-all text-gray-700 font-medium placeholder:text-gray-300 #{'ring-2 ring-error/40 bg-error/5' if watchlist.errors[:url].any?}", placeholder: "https://example.com/event-page" %>
     
     <% if watchlist.errors[:url].any? %>
       <p class="text-error text-xs font-semibold pl-4 flex items-center gap-1">

--- a/app/views/watchlists/_watchlist_card.html.erb
+++ b/app/views/watchlists/_watchlist_card.html.erb
@@ -19,8 +19,18 @@
       <div class="min-w-0 flex-1 pr-8 <%= 'opacity-60' if is_past || watchlist.is_done? %>">
         <div class="flex flex-wrap items-center gap-1.5 mb-2">
           <% if watchlist.start_at.present? %>
-            <time class="font-label text-xs text-on-surface-variant/70">
+            <time class="inline-flex items-center gap-1.5 font-label text-xs text-on-surface-variant/70">
+              <span class="text-[#2d6489] font-bold">
+                開始
+              </span>
               <%= watchlist.start_at.strftime("%Y.%m.%d %H:%M") %>
+            </time>
+          <% elsif watchlist.end_at.present? %>
+            <time class="inline-flex items-center gap-1.5 font-label text-xs text-on-surface-variant/70">
+              <span class="text-[#2d6489] font-bold">
+                締切
+              </span>
+              <%= watchlist.end_at.strftime("%Y.%m.%d %H:%M") %>
             </time>
           <% end %>
 

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -169,7 +169,7 @@
         <span class="material-symbols-outlined text-primary/60 text-xl">description</span>
         <span class="text-primary/60 text-xs font-bold uppercase tracking-widest font-headline">メモ・思い出</span>
       </div>
-      <div class="w-full min-h-[140px] px-8 py-6 bg-[#f0f4f8]/80 border-none rounded-[32px]">
+      <div class="w-full min-h-[140px] px-1 py-1 bg-[#f0f4f8]/80 border-none rounded-[32px]">
         <p class="text-gray-700 leading-relaxed whitespace-pre-wrap font-medium text-sm md:text-base">
           <%= @watchlist.memo.presence || "メモはまだありません。" %>
         </p>

--- a/app/views/welcome_mailer/send_welcome_email.html.erb
+++ b/app/views/welcome_mailer/send_welcome_email.html.erb
@@ -1,7 +1,7 @@
 <div style="font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif; color: #333333; max-width: 600px; margin: 0 auto; padding: 24px; background-color: #fdfdfd; border: 1px solid #eef0f2; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.02);">
   
   <h2 style="font-size: 18px; font-weight: 600; line-height: 1.5; color: #004A77; margin-bottom: 20px; border-bottom: 1px solid #edf2f7; padding-bottom: 12px;">
-    FanPocketへようこそ！
+    FanPocketへようこそ🌟
   </h2>
   
   <div style="font-size: 14px; line-height: 1.7; color: #4a5568; margin-bottom: 32px;">

--- a/app/views/welcome_mailer/send_welcome_email.text.erb
+++ b/app/views/welcome_mailer/send_welcome_email.text.erb
@@ -1,4 +1,4 @@
-FanPocketへようこそ！
+FanPocketへようこそ🌟
 
 <%= @user.email %> 様
 


### PR DESCRIPTION
## 概要

UI/UX・表示の最終調整を行いました。
一覧画面や入力フォーム、詳細画面、メール、PCヘッダー、日付候補選択UIの表示・操作性を改善しました。

## 背景

最終バグチェック・本番環境での全機能動作確認を行う前に、気になっていたUI/UXや表示上の不統一を修正し、アプリ全体の使いやすさと統一感を整えるためです。

closes #156

## 変更内容

- メールの差出人設定を `ApplicationMailer` に集約し、差出人表示を「FanPocket」に統一
- 一覧画面の日時表示を改善
  - 開始日時がある場合は「開始」と開始日時を表示
  - 開始日時がなく締切日時のみの場合は「締切」と締切日時を表示
- URL入力フォームのプレースホルダー位置を他の入力フォームと統一
- 詳細画面のメモ表示位置を調整
- PC表示でヘッダーがスクロール時も画面上部に固定されるよう調整
- ウェルカムメールの見出しに絵文字を追加
- 通知メールの件名に通知内容に応じた絵文字を追加
  - 3日前通知：📅
  - 前日通知：🌟
  - 当日締切通知：⏰
  - 開始当日通知：✨
- 日付候補の「開始日時にする」「締切日時にする」を選択した後、選択UIが閉じるよう改善
- Flatpickrのイベントコールバックをアロー関数で包み、Stimulus Controllerの `this` を保持するよう修正

## 確認方法

- メールの差出人が「FanPocket」として表示されることを確認
- 一覧画面で開始日時がある予定に「開始」と日時が表示されることを確認
- 一覧画面で締切日時のみの予定に「締切」と日時が表示されることを確認
- 開始日時・締切日時の両方がある場合は開始日時が表示されることを確認
- URL入力フォームのプレースホルダー位置を確認
- 詳細画面のメモ表示位置を確認
- PC表示でスクロールしてもヘッダーが画面上部に固定されることを確認
- 日付候補から開始日時・締切日時を入力すると選択UIが閉じることを確認
- 別の日付候補を開いた場合も、開いていた選択UIが閉じることを確認
- Flatpickrから直接日時を変更した場合もコンソールエラーが発生しないことを確認
- `bundle exec rubocop` が通ることを確認

## 影響範囲

- 予定一覧画面
- 予定登録・編集フォーム
- 予定詳細画面
- PC表示の共通ヘッダー
- ウェルカムメール
- 各種リマインド通知メール
- 日付候補選択UI
- Flatpickrを利用した日時入力
- メール送信元の共通設定

## スクリーンショット
-  一覧画面
<img width="1256" height="604" alt="image" src="https://github.com/user-attachments/assets/4eac42c2-a74f-46c6-bbd5-6c08fb8fb886" />

- 詳細画面のメモ部分
<img width="946" height="331" alt="image" src="https://github.com/user-attachments/assets/97510a19-78af-4b5e-bf68-e449540fd066" />

-  PC画面のヘッダー
<img width="1919" height="990" alt="image" src="https://github.com/user-attachments/assets/bb0209e9-f22c-4367-ba5b-621eaf530af4" />

## 補足

- 一覧画面の「開始」「締切」は日時の意味を示すラベルとして表示し、予定の状態を示す既存の色分けとは役割を分けています。
- 通知メールは件名にのみ通知内容に応じた絵文字を追加し、本文は読みやすさを優先して既存のシンプルな構成を維持しています。
- メールアドレス変更やパスワード関連など、アカウント・セキュリティ系メールには絵文字を追加していません。
- Flatpickrのイベントコールバックをアロー関数で包むことで、イベント実行時にもStimulus Controllerの `this` を保持できるよう修正しました。