### PR TITLE
本番環境での最終動作確認とUI調整

### DIFF
--- a/app/javascript/controllers/flatpickr_controller.js
+++ b/app/javascript/controllers/flatpickr_controller.js
@@ -10,6 +10,7 @@ export default class extends Controller {
       enableTime: true,
       dateFormat: "Y-m-d H:i",
       minuteIncrement: 1,
+      disableMobile: true,
     })
   }
 }

--- a/app/javascript/controllers/flatpickr_controller.js
+++ b/app/javascript/controllers/flatpickr_controller.js
@@ -10,7 +10,6 @@ export default class extends Controller {
       enableTime: true,
       dateFormat: "Y-m-d H:i",
       minuteIncrement: 1,
-      disableMobile: true,
     })
   }
 }

--- a/app/views/watchlists/_watchlist_card.html.erb
+++ b/app/views/watchlists/_watchlist_card.html.erb
@@ -71,10 +71,9 @@
         <% if watchlist.tags.any? %>
           <div class="mt-1 flex flex-wrap gap-x-2 gap-y-1">
             <% watchlist.tags.each do |tag| %>
-              <%= link_to watchlists_path(tag_id: tag.id),
-                          class: "text-sm font-medium text-primary/70 hover:opacity-70" do %>
+              <span class="text-sm font-medium text-primary/70">
                 #<%= tag.name %>
-              <% end %>
+              </span>
             <% end %>
           </div>
         <% end %>

--- a/app/views/watchlists/show.html.erb
+++ b/app/views/watchlists/show.html.erb
@@ -169,10 +169,8 @@
         <span class="material-symbols-outlined text-primary/60 text-xl">description</span>
         <span class="text-primary/60 text-xs font-bold uppercase tracking-widest font-headline">メモ・思い出</span>
       </div>
-      <div class="w-full min-h-[140px] px-1 py-1 bg-[#f0f4f8]/80 border-none rounded-[32px]">
-        <p class="text-gray-700 leading-relaxed whitespace-pre-wrap font-medium text-sm md:text-base">
-          <%= @watchlist.memo.presence || "メモはまだありません。" %>
-        </p>
+      <div class="w-full px-5 py-4 bg-[#f0f4f8]/80 border-none rounded-[32px]">
+        <p class="text-gray-700 leading-8 whitespace-pre-line break-words font-medium text-sm md:text-base"><%= @watchlist.memo.presence || "メモはまだありません。" %></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要

本番環境（Render）で主要機能の最終動作確認を行いました。
確認中に見つかったメモ表示・一覧のタグ表示についてUIを修正しました。

## 背景

本リリース前に、本番環境でユーザー登録・SNS認証・予定管理・通知などの主要機能が正常に動作することを確認するためです。

また、実機確認中に見つかった表示上の違和感についても調整しました。

closes #97

## 変更内容

- 本番環境（Render）で主要機能の動作確認
- メモ表示のレイアウトを改善
  - `whitespace-pre-wrap` から `whitespace-pre-line` に変更
  - ERB内の改行・インデントによる不要な空白を解消
  - メモの内容量に応じて高さが変わるよう調整
  - 長い文字列がはみ出さないよう `break-words` を追加
- 一覧画面のタグ表示を `link_to` から `span` に変更
  - タグ検索は検索機能に任せ、一覧では情報表示のみに変更

## 確認方法

本番環境およびiPhone実機で以下を確認しました。

- 予定の新規登録・編集・削除が正常に行えること
- URLから候補日時を取得できること
- タグの登録・表示が正常であること
- 完了状態が正常に表示されること
- Googleアカウントで新規登録・ログインできること
- Googleアカウント連携が正常に行えること
- 連携済みGoogleアカウントを再度連携した場合に「すでに連携されています」と表示されること
- LINEログインが正常に行えること
- Googleアカウントでの新規登録時にウェルカムメールが届くこと
- パスワード関連メールが届くこと
- メール通知をOFFにした場合、メールは送信されずアプリ内通知は届くこと
- LINE開始10分前通知をOFFにした場合、LINEは送信されずアプリ内通知は届くこと
- LINE締切3時間前通知をOFFにした場合、LINEは送信されずアプリ内通知は届くこと
- メモの改行・折り返し・余白が自然に表示されること
- 一覧のタグがリンクではなく表示のみになっていること
- iPhone実機で一覧表示が崩れていないこと

## 影響範囲

- 予定詳細画面のメモ表示
- 予定一覧画面のタグ表示

主要機能については動作確認のみで、今回の修正によるロジック変更はありません。

## スクリーンショット

### メモ表示

修正前：
<img width="1003" height="308" alt="image" src="https://github.com/user-attachments/assets/3364bb04-4206-4d1f-80a4-d83903d5fde1" />

修正後：
<img width="916" height="391" alt="image" src="https://github.com/user-attachments/assets/cf350839-a469-40db-a4b5-4f69a3bcc33a" />

## 補足

- iPhoneの日時入力について、Flatpickrの `disableMobile: true` を使用する方法も実機検証しましたが、特に時間入力の操作性が低下したため採用せず、iOSのネイティブUIを維持しています。
- 日時入力値の表示位置については、必要に応じて本リリース後の別IssueでUI/UX改善を検討します。
- 通知はGAS / GitHub Actionsの実行タイミングによって多少遅延する場合がありますが、メール・LINE・アプリ内通知および通知設定のON/OFFが正常に機能することを確認しました。
- 本リリース後に発見された不具合・改善点については、必要に応じて別Issueで対応します。