### PR TITLE
共通ヘッダーのロゴ・タイトル表示バランスを調整

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -26,12 +26,12 @@
       </button>
     </div>
 
-    <div class="flex items-center gap-2 bg-white/50 px-3 py-1.5 rounded-full border border-white shadow-sm">
+    <div class="flex items-center gap-1.5 bg-white/50 pl-3 pr-5 py-1.5 rounded-full border border-white shadow-sm">
       <%= image_tag "logo.png",
-          class: "w-8 h-8 md:w-9 md:h-9 object-contain",
+          class: "w-9 h-9 md:w-10 md:h-10 object-contain",
           alt: "" %>
 
-      <span class="font-headline font-bold text-xl md:text-2xl tracking-tight text-primary">
+      <span class="font-headline font-bold text-xl tracking-tight text-primary">
         FanPocket
       </span>
     </div>


### PR DESCRIPTION
## 概要

共通ヘッダーに表示しているロゴと「FanPocket」のサイズ・間隔・余白を調整しました。
ピル型背景内で、ロゴとタイトルがバランスよく見えるように改善しています。

## 背景

ロゴに対してタイトルの視覚的な存在感が大きく、ピル型背景内の左右の余白にも差があるように見えていたためです。

closes #162

## 変更内容

- ロゴの表示サイズを調整
- ロゴとタイトルの間隔を `gap-1.5` に変更
- タイトルの文字サイズをスマートフォン・PCともに `text-xl` に統一
- ピル型背景内の余白を `pl-3 pr-5` に変更
- ロゴ画像内の余白を考慮し、左右が視覚的に均等に見えるよう調整

## 確認方法

- スマートフォン表示で、ロゴとタイトルのバランスに問題がないことを確認
- PC表示で、ロゴとタイトルのバランスに問題がないことを確認
- ピル型背景内の左右の余白が自然に見えることを確認
- ロゴやタイトルが枠からはみ出していないことを確認
- 共通ヘッダーの既存レイアウトや機能に問題がないことを確認

## 影響範囲

- 共通ヘッダーのロゴ・タイトル表示
- アプリ内の各画面で使用している共通ヘッダー
- ヘッダー以外の画面や機能、データ処理への影響なし

## スクリーンショット

### 変更前
<img width="709" height="114" alt="image" src="https://github.com/user-attachments/assets/8326e848-5ec0-4bfd-93eb-ddabec2950fc" />

### 変更後
<img width="486" height="135" alt="image" src="https://github.com/user-attachments/assets/322f3472-9fad-450b-800a-066582dc5d51" />

## 補足

ロゴ画像自体に含まれる余白の影響で、CSS上の左右の余白が同じでも視覚的には不均等に見えていました。

ロゴを左側へ移動すると枠線に重なって見えたため、最終的には左余白を維持しつつ右余白を広げることで、視覚的なバランスを整えました。