### PR TITLE
iOSの日時入力の文字位置を調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -47,3 +47,10 @@
   position: relative;
   z-index: 1;
 }
+
+/* iOSの日時入力で、入力後の文字位置を他のフォームと揃える */
+@supports (-webkit-touch-callout: none) {
+  input.flatpickr-mobile {
+    text-indent: 1rem;
+  }
+}


### PR DESCRIPTION
## 概要

iOS実機で、開始日時・締切日時の入力後の文字位置を他の入力フォームと揃えました。
iOS標準の日時選択の操作性はそのまま維持しています。

## 背景

iPhone実機では、開始日時・締切日時の入力後の文字だけが、タイトルやタグなどの入力文字より左側に表示されていました。

FlatpickrがiOS向けに生成するネイティブ日時入力の表示差を調整するため、対応しました。

closes #160

## 変更内容

* Flatpickrがモバイル用に生成する`.flatpickr-mobile`を調整
* iOS系ブラウザに限定して`text-indent: 1rem`を指定
* 入力後の日時を右へ移動し、他の入力フォームと文字位置を統一
* iOS標準の日時選択を維持するため、`disableMobile: true`は使用しない方針を採用

## 確認方法

* iPhone実機の新規登録画面で開始日時・締切日時を入力し、他のフォームと文字位置が揃うことを確認
* iPhone実機の編集画面で入力済みの開始日時・締切日時が同じ位置に表示されることを確認
* iOS標準の日時選択画面がこれまでどおり開くことを確認
* 日時を変更して正常に保存できることを確認
* PCの通常表示・レスポンシブ表示に変化がないことを確認
* RuboCopおよびRSpecが通ることを確認

## 影響範囲

* iOS実機の予定新規登録・編集画面にある開始日時・締切日時
* PC表示やタイトル・タグなど、日時以外の入力フォームには影響なし
* AndroidやPC用のFlatpickrには適用されない

## スクリーンショット

### 変更前
<img width="381" height="826" alt="image" src="https://github.com/user-attachments/assets/504f2b5b-22c6-4946-867d-46e1c9e26955" />


iOS実機で、入力後の日時が他の入力フォームより左寄りに表示されている画面を添付

### 変更後
<img width="380" height="831" alt="image" src="https://github.com/user-attachments/assets/d56e7628-f0b9-4a81-9940-be5b3bc67fc1" />

## 補足

`disableMobile: true`によってiPhoneでもFlatpickr独自の入力画面を使用する方法も検討しましたが、日時・時間指定の操作性を考慮し、現在のiOS標準の日時選択を維持しました。

iOS向けの日時inputだけを対象にすることで、他の端末やフォームへ影響しない実装にしています。
