### PR TITLE
ログイン画面にサービス説明を追加

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,3 @@
-<head>
-  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;700;800&amp;family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet"/>
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
-</head>
 <div class="relative flex flex-col items-center justify-start min-h-screen pt-16 pb-32 px-6">
   <div class="relative z-10 w-full max-w-[420px] flex flex-col space-y-10">
 
@@ -9,7 +5,9 @@
       <div class="relative w-44 h-44 flex items-center justify-center bg-white rounded-full shadow-md overflow-hidden border border-gray-100">
         <%= image_tag "logo.png", alt: "FanPocket Logo", class: "w-full h-full object-contain" %>
       </div>
-      <h1 class="text-3xl font-bold tracking-tight text-primary opacity-90">FanPocket</h1>
+      <h1 class="text-3xl md:text-4xl font-bold tracking-tight text-primary opacity-90">
+        FanPocket
+      </h1>
       <p class="text-gray-400 text-sm font-medium">新しいアカウントを作成</p>
     </header>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,21 +3,32 @@
   <div class="relative z-10 w-full max-w-[420px] flex flex-col space-y-10">
     <!-- Header & Logo Section -->
     <header class="flex flex-col items-center text-center space-y-4">
-      <!-- ロゴの周りを白くし、黒い枠を消す -->
       <div class="relative w-44 h-44 flex items-center justify-center bg-white rounded-full shadow-md overflow-hidden border border-gray-100">
         <%= image_tag "logo.png", alt: "FanPocket Logo", class: "w-full h-full object-contain" %>
       </div>
-      <h2 class="font-bold text-3xl tracking-tight text-primary opacity-90">FanPocket</h2>
+
+      <div class="space-y-3">
+        <h1 class="text-3xl md:text-4xl font-bold tracking-tight text-primary opacity-90">
+          FanPocket
+        </h1>
+
+        <p class="text-base font-semibold text-primary/80">
+          推し活の大切な予定を、忘れないために。
+        </p>
+
+        <p class="text-sm leading-7 text-gray-500">
+          URLを登録して、開始や締切をまとめて管理。<br>
+          大切な予定が近づいたらお知らせします。
+        </p>
+      </div>
     </header>
 
-    <div class="w-full mt-6 -mb-2">
-      <% if alert %>
-        <div class="alert alert-soft alert-error rounded-2xl p-4 shadow-sm mb-6 flex items-center space-x-3">
-          <span class="material-symbols-outlined text-[20px]">warning</span>
-          <span class="text-sm font-bold text-left"><%= alert %></span>
-        </div>
-      <% end %>
-    </div>
+    <% if alert %>
+      <div class="alert alert-soft alert-error rounded-2xl p-4 shadow-sm flex items-center space-x-3">
+        <span class="material-symbols-outlined text-[20px]">warning</span>
+        <span class="text-sm font-bold text-left"><%= alert %></span>
+      </div>
+    <% end %>
 
     <!-- Login Form Section -->
     <main class="w-full">


### PR DESCRIPTION
## 概要

ログイン画面にFanPocketのサブタイトルとサービス説明を追加しました。
初めて利用するユーザーにも、推し活の予定を管理・通知するサービスであることが伝わるようにしました。

## 背景

サービス名だけではFanPocketの目的や基本的な利用イメージが初見で伝わりにくかったためです。

closes #166

## 変更内容

- ログイン画面にサブタイトルとサービス説明を追加
- サービス名を主見出しの`h1`へ変更
- PCではサービス名を大きく表示するようレスポンシブ対応
- ログインエラーがない場合に空要素が残らないようアラート表示を整理
- アラート周辺の余白を調整
- 新規登録画面のサービス名の表示サイズをログイン画面と統一
- 新規登録画面に重複して記述されていた`head`要素を削除

## 確認方法

- PC・スマートフォンでログイン画面の表示を確認
- PC・スマートフォンで新規登録画面の表示を確認
- ログイン失敗時にアラートが正しく表示されることを確認
- RuboCopが通ることを確認
- RSpecが通ることを確認

## 影響範囲

- ログイン画面
- 新規登録画面
- 認証処理やログイン後の各機能への影響はありません

## スクリーンショット

- ログイン画面
<img width="1650" height="964" alt="image" src="https://github.com/user-attachments/assets/e0b00bf8-6853-4055-8d7c-0a31847ed221" />

## 補足

サービスの目的と基本的な利用イメージのみをログイン画面で伝え、対応済み・未対応などの詳しい操作方法は既存の使い方ガイドで説明する構成としています。